### PR TITLE
#58 invites logic definition

### DIFF
--- a/docs/descriptive/invites-logic-definition.adoc
+++ b/docs/descriptive/invites-logic-definition.adoc
@@ -53,7 +53,7 @@ Users with the appropriate permissions can include:
 * Role-Based
 ** Owners and designated Members may send invitations.
 
-By default, invite permissions can only be made by Owners, unless Mmber permissions are expanded.
+By default, invite permissions can only be made by Owners, unless Member permissions are expanded.
 
 == Invitation Lifecycle States
 
@@ -116,17 +116,18 @@ By default, invite permissions can only be made by Owners, unless Mmber permissi
 
 * Direct Invite
 ** Recipient receives invite through application.
+** Invited user must have an account or create one to accept.
 
 * Link Invite
 ** Shareable link allows multiple recipients.
 ** Requires validation step before access is granted.
+** Will require user to create an account or log in before joining.
 
 == Security Considerations
 
 - Invitations must use secure tokens.
 - Tokens should be single-use or time-bound.
 - Server-side validation required for all joins.
-- Audit logging recommended for invite creation and acceptance.
 
 == Summary Rules
 


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #58 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Creates an adoc file for the invites logic definition in the "descriptive" directory 
- Describes the logic related to how the invite logic should work.

### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
This change is necessary to provide a universal guide within the project for how invites should work.  

This is a summary of the proposed logic:
  -  Only Owners and members with the right permissions can send invites. 
  -  To avoid duplicate invites, limit invites to one *active* invite per user. Allow invites to be editable by inviter.
  - Invites should be shared via the application or links that can be shared externally.

---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [ ] Invitation lifecycle is described verbally
- [ ] Rules for invite management are described 
- [ ] Edge cases are identified and managed
- [ ] Invitation states are defined

---

## 🧪 Testing (if applicable)
<!-- Describe how you tested these changes -->
### Test Steps:
N/A

## 👀 Reviewers
<!-- Tag team members for review -->
@andreasegarra 
@Kay9876 
@LuisJCruz 
