### PR TITLE
59 permission rules definition

### DIFF
--- a/docs/descriptive/ownership models and rules/permission-rules-definition.adoc
+++ b/docs/descriptive/ownership models and rules/permission-rules-definition.adoc
@@ -101,7 +101,7 @@ To handle conflicts, we can implement the following policies:
 
 - Precedence of most restrictive permission: To prevent edit conflicts, we can implement a policy where the most restrictive permission takes precedence. For example, if a Member has edit permissions on an item but the Owner wants to delete it, the Owner's action would take precedence and the item would be deleted. However, if the Member has edit permissions that allow them to prevent deletion, then the deletion would be denied.
 
-- Multiple invitations for the same user: If a user receives multiple invitations from different Owners for the same household, the system should allow the user to accept only one invitation. Once an invitation is accepted, any other pending invitations for that user and household should be automatically revoked.
+- Only one active Inivite: If a user receives multiple invitations from different Owners for the same household, the system should allow the user to accept only one invitation. Once an invitation is accepted, any other pending invitations for that user and household should be automatically revoked.
 
 == Escalation & Transfer Scenarios
 


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #59 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Creates an adoc file for the permission rules definition in the "descriptive" directory.
- I believe this belongs in section  2.2 of the documentation.
- Describes the logic related to how the permissions based on roles should work within a household.
- Addresses some conflicts that may arise due to conflicting permissions
- Includes member demotion/promotion flow descriptions.

### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
This change is necessary to provide a universal guide within the project for how permissions should work.  

This is a summary of the proposed logic:
  -  Establish member and owner rules.
  - For exceptions managing, permissions are restricted based on moder (User-Owned vs Group-Owned)
  - Conflict types are managed by policies such as "Precedence of most restrictive permission" to avoid item edit conflicts and "Only one active invite" in the case where multiple household members issue invitations to the same user.
  - Ownership transfer steps and rules are defined.

---

## ✅ Checklist
<!-- Mark completed items with [x] -->

- [ ] Roles and allowed actions are mentioned.
- [ ] Permission inheritance or overrides are addressed.
- [ ] Defined behavior when permissions conflict.

---

## 🧪 Testing (if applicable)
<!-- Describe how you tested these changes -->
### Test Steps:
N/A

## 👀 Reviewers
<!-- Tag team members for review -->
@andreasegarra 
@Kay9876 
@LuisJCruz 
