### PR TITLE
Reduce Doc without loosing clarity 

### DIFF
--- a/docs/2-descriptive/implementation/software-design/database_schema.adoc
+++ b/docs/2-descriptive/implementation/software-design/database_schema.adoc
@@ -1,34 +1,16 @@
 = Database Schema
-:showtitle: true 
+:showtitle: true
 
-While issue #15 stated that the database consists of three tables: items, users, and owners; further iterating called for changes in how entities would be modeled. Team discussions lead to including that users can track the inventory of multiple homes, and that a home can have multiple users tracking its inventory. These considerations lead to the consideration of entities: user, owner, home, room, item, and product.
+The database schema models users, homes, rooms, products, and stock (item instances). An earlier draft of the schema existed; it was revised in issue #122 (Lecture Topic Task: Inconsistencies with domain terminology and household item documentation).
 
-image::outdated_stock_ERD.png[] 
-Figure 1: ER diagram for our project's entities.
+The revision addressed a conflict between the Group-Owned Inventory model and the original stock representation: the original schema required each item to have exactly one owner. The relationship between Owner and Item was changed to many-to-many, and a new *Owns* table was added so an item can be owned by multiple owners while an owner can still own multiple items.
 
 Here, users manage multiple homes that contain multiple rooms. Rooms can only belong to one home, and can contain multiple household items. Every item is contained in a room and references a product. Every item is also owned by a single owner. We want to track items belonging to owners, even if those owners are not users. An example of this would be a user attributing items to a roommate who is not themself a user.
 
-Translating this ER to a table diagram, the final entities are:
+image::stock_ERD.png[]
+Figure 1: ER diagram for the project entities.
 
-image::outdated_stock_table_diagram.png[] 
-Figure 2: Table diagram for our project's backend.
+image::stock_table_diagram.png[]
+Figure 2: Table diagram for the backend.
 
-## Revision
-As part of issue #122 [Lecture Topic Task]: Inconsistencies with domain terminology and 
-household item documentation, this diagrams were revised to address a weak conflict between
-the Grouped-Owned Inventory model on the Shared Inventory Definition document and this stock 
-database representation. The model was satisfiable by this schema only when Items have one and only one Owner.
 
-This revision then changed the relationship between Owner and Item to be many-to-many, and
-as a consequence, added a new table Owns to represent the relationship. This change now 
-allows for an Item to be owned by multiple Owners while keeping the ability of an Owner to 
-own multiple Items.
-
-image:stock_ERD.png[] 
-Figure 3: Revised ER diagram for our project's entities.
-
-As mentioned above, the relationship between Owner and Item is now many-to-many, which 
-requires the creation of a new Owns table.
-
-image:stock_table_diagram.png[] 
-Figure 4: Revised table diagram for our project's backend.

--- a/docs/4-specific-topics/personas/personas.adoc
+++ b/docs/4-specific-topics/personas/personas.adoc
@@ -21,7 +21,7 @@ Personas represent key user/stakeholder types. Aim for 3-4 personas. Each person
 ** Severe time constraints due to a heavy class and work schedule.
 ** Limited mental bandwidth for tracking chores; relies heavily on his smartphone for organization.
 * *Scenario:*
-Mateo comes home late after a grueling day of classes. He remembers buying chicken breasts earlier in the week and plans to quickly pan-fry them for dinner. When he opens the fridge, he realizes he actually bought them almost a week and a half ago, and they have spoiled. Frustrated, he orders an expensive pizza delivery, breaking his weekly food budget, and later realizes he also has three open bottles of ketchup in the pantry. Success for Mateo looks like receiving a push notification on his phone the day before his chicken expires, and being able to quickly check an app at the supermarket to confirm he doesn't need to buy a fourth bottle of ketchup.
+Mateo comes home late after a grueling day of classes. He remembers buying chicken breasts earlier in the week and plans to quickly pan-fry them for dinner. When he opens the fridge, he realizes he actually bought them almost a week and a half ago, and they have spoiled. Frustrated, he orders an expensive pizza delivery, breaking his weekly food budget, and later realizes he also has three open bottles of ketchup in the pantry. Success for Mateo looks like receiving an alert/notification (delivery TBD / in-app baseline) the day before his chicken expires, and being able to quickly check an app at the supermarket to confirm he doesn't need to buy a fourth bottle of ketchup.
 
 === Persona 2: Sofia, The Budget-Conscious Roommate
 * *Role:* Student living with roommates and Budget-conscious student


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
Closes #263

---

## 📝 Description

### What changed?
- **Personas:** In Persona 1 (Mateo), the scenario success criteria no longer say "push notification on his phone." They now say "alert/notification (delivery TBD / in-app baseline)" so it matches the M1 baseline (in-app alerts; delivery method TBD).
- **Section 2.3.3 Database Schema:** Removed the outdated stock ERD and outdated stock table diagram. Replaced that content with a short note that an earlier draft existed and was revised in issue #122 *(Lecture Topic Task: Inconsistencies with domain terminology and household item documentation)*.
- **Section 2.3.3 Database Schema:** Kept only the final ER diagram and table diagram as the single source of truth (now Figure 1 and Figure 2). Trimmed the "why the schema changed" explanation to three lines (conflict with Group-Owned Inventory model, one-owner constraint, many-to-many + Owns table).
- **Section 2.2.1.6 Features:** No changes (left as-is per issue).

### Why was this change necessary?
The requirements doc was longer than needed for Milestone 1: personas implied push notifications as a confirmed M1 deliverable when only in-app alerts are committed, and the Database Schema section read like a changelog (old + new diagrams and long revision text). Trimming these areas shortens the doc and keeps it M1-appropriate without dropping requirement coverage.

---

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [ ] Branch is up to date with base branch

---

## 🧪 Testing (if applicable)


### Test Results:
- Persona 1 no longer references push as a confirmed M1 deliverable.
- Section 2.3.3 contains only the final diagrams and a one-line reference to the earlier draft; "why it changed" is three lines.
- Document length reduced with no loss of requirement coverage.

---

## 📸 Screenshots/Videos (if applicable)
N/A — documentation-only changes.

---

## 👀 Reviewers
@