### PR TITLE
Created export to PDF button that can be added to any report page as …

### DIFF
--- a/src/lib/core/data/services/pdf_export_service.dart
+++ b/src/lib/core/data/services/pdf_export_service.dart
@@ -1,0 +1,114 @@
+import 'dart:typed_data';
+
+import 'package:intl/intl.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:printing/printing.dart';
+
+class PdfExportService {
+  Future<void> exportInventoryStockReport({
+    required DateTime startDate,
+    required int page,
+    required List<Map<String, dynamic>> categories,
+    required List<Map<String, dynamic>> items,
+    Uint8List? chartImage,
+  }) async {
+    final pdf = pw.Document();
+
+    final generatedAt = DateTime.now();
+    final endDate = startDate.add(const Duration(days: 6));
+
+    final dateRange =
+        '${DateFormat('MMMM d').format(startDate)} - ${DateFormat('d, y').format(endDate)}';
+
+    pdf.addPage(
+      pw.MultiPage(
+        margin: const pw.EdgeInsets.all(24),
+        build: (context) => [
+          pw.Text(
+            'Inventory Stock Summary',
+            style: pw.TextStyle(
+              fontSize: 24,
+              fontWeight: pw.FontWeight.bold,
+            ),
+          ),
+          pw.SizedBox(height: 8),
+          pw.Text('Report range: $dateRange'),
+          pw.Text('Generated: ${DateFormat('yyyy-MM-dd HH:mm').format(generatedAt)}'),
+          pw.Text('Page: ${page + 1}'),
+          pw.SizedBox(height: 24),
+          if (chartImage != null) ...[
+            pw.Center(
+              child: pw.Text(
+                'Bar Chart',
+                style: pw.TextStyle(
+                  fontSize: 16,
+                  fontWeight: pw.FontWeight.bold,
+                ),
+              ),
+            ),
+            pw.SizedBox(height: 12),
+            pw.Center(
+              child: pw.Container(
+                constraints: const pw.BoxConstraints(
+                  maxWidth: 450,
+                  maxHeight: 260,
+                ),
+                child: pw.Image(
+                  pw.MemoryImage(chartImage),
+                  fit: pw.BoxFit.contain,
+                ),
+              ),
+            ),
+            pw.SizedBox(height: 24),
+          ],
+          pw.Text(
+            'Category Summary',
+            style: pw.TextStyle(
+              fontSize: 16,
+              fontWeight: pw.FontWeight.bold,
+            ),
+          ),
+          pw.SizedBox(height: 8),
+          pw.TableHelper.fromTextArray(
+            headerStyle: pw.TextStyle(fontWeight: pw.FontWeight.bold),
+            headerDecoration: const pw.BoxDecoration(),
+            cellAlignment: pw.Alignment.centerLeft,
+            headers: const ['Category', 'Quantity'],
+            data: categories
+                .map((c) => [c['name'], c['quantity'].toString()])
+                .toList(),
+          ),
+          pw.SizedBox(height: 20),
+          pw.Text(
+            'Items',
+            style: pw.TextStyle(
+              fontSize: 16,
+              fontWeight: pw.FontWeight.bold,
+            ),
+          ),
+          pw.SizedBox(height: 8),
+          pw.TableHelper.fromTextArray(
+            headerStyle: pw.TextStyle(fontWeight: pw.FontWeight.bold),
+            headerDecoration: const pw.BoxDecoration(),
+            cellAlignment: pw.Alignment.centerLeft,
+            headers: const ['Item', 'Category', 'Quantity', 'Status'],
+            data: items
+                .map(
+                  (i) => [
+                i['name'],
+                i['category'],
+                i['quantity'].toString(),
+                i['status'],
+              ],
+            )
+                .toList(),
+          ),
+        ],
+      ),
+    );
+
+    await Printing.layoutPdf(
+      onLayout: (format) async => pdf.save(),
+    );
+  }
+}

--- a/src/lib/features/reports/presentation/pages/inventory_stock_report_page.dart
+++ b/src/lib/features/reports/presentation/pages/inventory_stock_report_page.dart
@@ -1,5 +1,10 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../core/data/services/pdf_export_service.dart';
 
 class InventoryStockReportPage extends StatelessWidget {
   const InventoryStockReportPage({super.key});
@@ -13,8 +18,61 @@ class InventoryStockReportPage extends StatelessWidget {
   }
 }
 
-class _ReportView extends StatelessWidget {
+class _ReportView extends StatefulWidget {
   const _ReportView();
+
+  @override
+  State<_ReportView> createState() => _ReportViewState();
+}
+
+class _ReportViewState extends State<_ReportView> {
+  final GlobalKey _chartKey = GlobalKey();
+
+  Future<Uint8List?> _captureChart() async {
+    try {
+      final boundary =
+      _chartKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+
+      if (boundary == null) return null;
+
+      final image = await boundary.toImage(pixelRatio: 3.0);
+      final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+
+      return byteData?.buffer.asUint8List();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _exportPdf(BuildContext context, ReportState state) async {
+    final pdfService = PdfExportService();
+
+    final categories = state.currentPageData
+        .map((c) => {
+      'name': c.name,
+      'quantity': c.quantity,
+    })
+        .toList();
+
+    final items = state.items
+        .map((i) => {
+      'name': i.name,
+      'category': i.category,
+      'quantity': i.quantity,
+      'status': i.status,
+    })
+        .toList();
+
+    final chartImage = await _captureChart();
+
+    await pdfService.exportInventoryStockReport(
+      startDate: state.startDate,
+      page: state.page,
+      categories: categories,
+      items: items,
+      chartImage: chartImage,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -29,23 +87,41 @@ class _ReportView extends StatelessWidget {
         ),
         title: const Text(
           'Inventory Stock Summary',
-          style: TextStyle(color: Colors.black87, fontSize: 18, fontWeight: FontWeight.w600),
+          style: TextStyle(
+            color: Colors.black87,
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+          ),
         ),
         centerTitle: false,
         actions: [
-          Container(
-            margin: const EdgeInsets.only(right: 16),
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            decoration: BoxDecoration(
-              color: const Color(0xFF8B9D7F),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Row(
-              children: const [
-                Text('Filters', style: TextStyle(color: Colors.white, fontSize: 14)),
-                SizedBox(width: 4),
-                Icon(Icons.arrow_drop_down, color: Colors.white, size: 20),
-              ],
+          BlocBuilder<ReportCubit, ReportState>(
+            builder: (context, state) {
+              return IconButton(
+                onPressed: () => _exportPdf(context, state),
+                icon: const Icon(Icons.picture_as_pdf, color: Colors.black87),
+                tooltip: 'Export to PDF',
+              );
+            },
+          ),
+          Padding(
+            padding: const EdgeInsets.only(right: 16),
+            child: Center(
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF8B9D7F),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: const [
+                    Text('Filters', style: TextStyle(color: Colors.white, fontSize: 14)),
+                    SizedBox(width: 4),
+                    Icon(Icons.arrow_drop_down, color: Colors.white, size: 20),
+                  ],
+                ),
+              ),
             ),
           ),
         ],
@@ -61,7 +137,11 @@ class _ReportView extends StatelessWidget {
                   children: const [
                     Text(
                       'March 9 - 15',
-                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: Colors.black87),
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.black87,
+                      ),
                     ),
                     Text(
                       '2026',
@@ -70,7 +150,10 @@ class _ReportView extends StatelessWidget {
                   ],
                 ),
               ),
-              _BarChart(data: state.currentPageData),
+              RepaintBoundary(
+                key: _chartKey,
+                child: _BarChart(data: state.currentPageData),
+              ),
               const SizedBox(height: 16),
               Expanded(child: _DataTable(items: state.items)),
               _SearchBar(),
@@ -89,7 +172,7 @@ class _BarChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final maxVal = data.isEmpty ? 100 : data.map((e) => e.quantity).reduce((a, b) => a > b ? a : b);
-    
+
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
       padding: const EdgeInsets.all(16),
@@ -128,7 +211,7 @@ class _BarChart extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 8),
-          Text('< Page ${context.read<ReportCubit>().state.page + 1} >', style: TextStyle(color: Colors.black)),
+          Text('< Page ${context.read<ReportCubit>().state.page + 1} >', style: const TextStyle(color: Colors.black)),
         ],
       ),
     );
@@ -203,9 +286,9 @@ class _StatusBadge extends StatelessWidget {
     final colors = status == 'OK'
         ? [const Color(0xFFD4EDDA), const Color(0xFF155724)]
         : status == 'LOW'
-            ? [const Color(0xFFFFF3CD), const Color(0xFF856404)]
-            : [const Color(0xFFF8D7DA), const Color(0xFF721C24)];
-    
+        ? [const Color(0xFFFFF3CD), const Color(0xFF856404)]
+        : [const Color(0xFFF8D7DA), const Color(0xFF721C24)];
+
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
       decoration: BoxDecoration(color: colors[0], borderRadius: BorderRadius.circular(4)),
@@ -256,21 +339,21 @@ class ReportCubit extends Cubit<ReportState> {
 class ReportState {
   final DateTime startDate = DateTime(2026, 3, 9);
   final int page = 0;
-  
+
   List<CategoryData> get currentPageData => page == 0
       ? [
-          CategoryData('Food', 44),
-          CategoryData('Kitchen', 20),
-          CategoryData('Cleaning', 38),
-          CategoryData('Hygiene', 24),
-          CategoryData('Bathroom', 30),
-        ]
+    CategoryData('Food', 44),
+    CategoryData('Kitchen', 20),
+    CategoryData('Cleaning', 38),
+    CategoryData('Hygiene', 24),
+    CategoryData('Bathroom', 30),
+  ]
       : [
-          CategoryData('Utilities', 64),
-          CategoryData('Medicine', 20),
-          CategoryData('Laundry', 0),
-        ];
-  
+    CategoryData('Utilities', 64),
+    CategoryData('Medicine', 20),
+    CategoryData('Laundry', 0),
+  ];
+
   List<ItemData> get items => [
     ItemData('Eggs', 'Food', 18, 'OK'),
     ItemData('Beans (cans)', 'Food', 15, 'OK'),

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -40,7 +40,10 @@ dependencies:
   flutter_bloc: ^9.1.1
   get_it: ^9.2.1
   swipe_image_gallery: ^0.11.0
-  google_fonts: ^6.2.1
+  google_fonts: ^8.0.2
+  intl: ^0.20.2
+  pdf: ^3.11.2
+  printing: ^5.14.0
 
 dev_dependencies:
   flutter_test:
@@ -51,7 +54,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
Closes #113 

---

## 📝 Description
Created an export to PDF button that can be added to any report page as needed.
-Exports charts/graphs.
-Exports Tables.
-Generates Metadata.

---

## ✅ Checklist
- [X] Users can export any report as a PDF file.
- [X] The generated PDF includes the report content, tables, and charts correctly.
- [X] The file can be saved or shared without permission errors.

---

## 📸 Screenshots/Videos (if applicable)
<img width="527" height="526" alt="image" src="https://github.com/user-attachments/assets/c50dd999-ada5-4b8b-902a-fdef5de0bd0c" />
<img width="328" height="731" alt="image" src="https://github.com/user-attachments/assets/f1cfbd1c-f468-48f2-b1b8-6b5f671a70bc" />
<img width="326" height="381" alt="image" src="https://github.com/user-attachments/assets/333fe1d9-7060-4246-ae05-3fadd5649be1" />

---

## 👀 Reviewers
@FabianVelezOcasio 
@LuisJCruz 
@Kay9876 
