### PR TITLE
Search Bar Functionalities for items inside reports and reports itself (Supabase integration testing was applied)

### DIFF
--- a/src/lib/config/injection_dependencies.dart
+++ b/src/lib/config/injection_dependencies.dart
@@ -10,6 +10,9 @@ import 'package:src/features/example_feature/domain/usecases/stream_todos.dart';
 import 'package:src/features/example_feature/domain/usecases/unmark_todo_completed.dart';
 import 'package:src/features/example_feature/domain/usecases/update_todo.dart';
 import 'package:src/features/example_feature/presentation/cubits/todo_cubit.dart';
+import 'package:src/features/reports/domain/repositories/supabase_report_repository.dart';
+import 'package:src/features/reports/domain/repositories/report_repositories.dart';
+import 'package:src/features/reports/presentation/cubit/report_list_cubit.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 final sl = GetIt.instance;
@@ -21,8 +24,10 @@ Future<void> initializeDependencies() async {
     anonKey: 'sb_publishable_1w1-TrfGRbG2nvDv-UUMVQ_EE2lj-HB',
   );
 
-  // Registering the app's Services
+  // Register SupabaseClient (FIX: added this line)
+  sl.registerLazySingleton<SupabaseClient>(() => Supabase.instance.client);
 
+  // Registering the app's Services
   sl.registerSingleton<SupabaseService>(
     SupabaseService(Supabase.instance.client),
   );
@@ -52,18 +57,20 @@ Future<void> initializeDependencies() async {
   /// they're not 100% standalone.
 
   /// Core Inventory
-
   // ...
 
   /// Alerts and Restock
-
   // ...
 
   /// Sharing and Budget
-
   // ...
 
   /// Reports and Insights
+  sl.registerLazySingleton<ReportRepository>(
+    () => SupabaseReportRepository(sl<SupabaseClient>()),
+  );
 
-  // ...
+  sl.registerFactory<ReportListCubit>(
+    () => ReportListCubit(sl<ReportRepository>()),
+  );
 }

--- a/src/lib/core/presentation/routes.dart
+++ b/src/lib/core/presentation/routes.dart
@@ -12,6 +12,8 @@ var mainRoutes = GoRoute(
   routes: [
     todosRoutes,
     inventoryStockReportRoute,
-    groceryListRoutes
+    groceryListRoutes,
+    //For testing Purposes
+    reportListRoute,
   ],
 );

--- a/src/lib/features/reports/domain/entities/report_metrics.dart
+++ b/src/lib/features/reports/domain/entities/report_metrics.dart
@@ -1,1 +1,22 @@
-class Report {}
+class Report {
+  final String id;
+  final String title;
+  final String description;
+  final DateTime createdAt;
+
+  Report({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.createdAt,
+  });
+
+  factory Report.fromJson(Map<String, dynamic> json) {
+    return Report(
+      id: json['id'],
+      title: json['title'],
+      description: json['description'],
+      createdAt: DateTime.parse(json['created_at']),
+    );
+  }
+}

--- a/src/lib/features/reports/domain/repositories/supabase_report_repository.dart
+++ b/src/lib/features/reports/domain/repositories/supabase_report_repository.dart
@@ -1,0 +1,40 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:src/features/reports/domain/entities/report_metrics.dart';
+import 'package:src/features/reports/domain/repositories/report_repositories.dart';
+
+class SupabaseReportRepository implements ReportRepository {
+  final SupabaseClient _client;
+
+  SupabaseReportRepository(this._client);
+
+  @override
+  Future<List<Report>> fetchReports() async {
+    final response = await _client
+        .from('reports')
+        .select()
+        .order('created_at', ascending: false);
+    return response.map((json) => Report.fromJson(json)).toList();
+  }
+
+  @override
+  Future<List<Report>> searchReports(String query) async {
+    if (query.isEmpty) {
+      return fetchReports();
+    }
+
+    final response = await _client
+        .rpc('search_reports', params: {'search_query': query}) as List<dynamic>;
+
+    return response.map((json) => Report.fromJson(json as Map<String, dynamic>)).toList();
+  }
+
+  @override
+  Future<Report> fetchReportById(String reportId) async {
+    final response = await _client
+        .from('reports')
+        .select()
+        .eq('id', reportId)
+        .single();
+    return Report.fromJson(response);
+  }
+}

--- a/src/lib/features/reports/presentation/cubit/report_list_cubit.dart
+++ b/src/lib/features/reports/presentation/cubit/report_list_cubit.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../domain/entities/report_metrics.dart';
+import '../../domain/repositories/report_repositories.dart';
+
+part 'report_list_state.dart';
+
+class ReportListCubit extends Cubit<ReportListState> {
+  final ReportRepository repository;
+  Timer? _debounce;
+
+  ReportListCubit(this.repository) : super(ReportListInitial());
+
+  Future<void> loadReports() async {
+    emit(ReportListLoading());
+    try {
+      final reports = await repository.fetchReports();
+      emit(ReportListLoaded(reports));
+    } catch (e) {
+      emit(ReportListError(e.toString()));
+    }
+  }
+
+  void search(String query) {
+    if (_debounce?.isActive ?? false) _debounce!.cancel();
+    _debounce = Timer(const Duration(milliseconds: 500), () async {
+      emit(ReportListLoading());
+      try {
+        final results = await repository.searchReports(query);
+        emit(ReportListLoaded(results));
+      } catch (e) {
+        emit(ReportListError(e.toString()));
+      }
+    });
+  }
+
+  @override
+  Future<void> close() {
+    _debounce?.cancel();
+    return super.close();
+  }
+}

--- a/src/lib/features/reports/presentation/cubit/report_list_state.dart
+++ b/src/lib/features/reports/presentation/cubit/report_list_state.dart
@@ -1,0 +1,17 @@
+part of 'report_list_cubit.dart';
+
+abstract class ReportListState {}
+
+class ReportListInitial extends ReportListState {}
+
+class ReportListLoading extends ReportListState {}
+
+class ReportListLoaded extends ReportListState {
+  final List<Report> reports;
+  ReportListLoaded(this.reports);
+}
+
+class ReportListError extends ReportListState {
+  final String message;
+  ReportListError(this.message);
+}

--- a/src/lib/features/reports/presentation/pages/inventory_stock_report_page.dart
+++ b/src/lib/features/reports/presentation/pages/inventory_stock_report_page.dart
@@ -4,6 +4,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart'; // <-- added for navigation
 import '../../../../core/data/services/pdf_export_service.dart';
 
 // ======================== Models ========================
@@ -109,10 +110,9 @@ class ReportCubit extends Cubit<ReportState> {
   void search(String query) {
     emit(state.copyWith(searchQuery: query));
   }
-
 }
 
-// ======================== UI (unchanged except for the above changes) ========================
+// ======================== UI ========================
 class InventoryStockReportPage extends StatelessWidget {
   const InventoryStockReportPage({super.key});
 
@@ -226,6 +226,12 @@ class _ReportViewState extends State<_ReportView> {
                 ),
               ),
             ),
+          ),
+          // Temporary navigation button to the reports list page
+          IconButton(
+            onPressed: () => context.push('/home/reports'),
+            icon: const Icon(Icons.list, color: Colors.black87),
+            tooltip: 'Go to Reports List',
           ),
         ],
       ),

--- a/src/lib/features/reports/presentation/pages/report_list_page_not_official.dart
+++ b/src/lib/features/reports/presentation/pages/report_list_page_not_official.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../cubit/report_list_cubit.dart';
+import '/../config/injection_dependencies.dart'; // Ajusta la ruta según tu proyecto
+
+//Only for Testing Purposes, not oficial Report Page
+
+class ReportListPage extends StatelessWidget {
+  const ReportListPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => sl<ReportListCubit>()..loadReports(),
+      child: const _ReportListView(),
+    );
+  }
+}
+
+class _ReportListView extends StatefulWidget {
+  const _ReportListView();
+
+  @override
+  State<_ReportListView> createState() => _ReportListViewState();
+}
+
+class _ReportListViewState extends State<_ReportListView> {
+  final TextEditingController _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController.addListener(() {
+      context.read<ReportListCubit>().search(_searchController.text);
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Reports'),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(60),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: TextField(
+              controller: _searchController,
+              decoration: InputDecoration(
+                hintText: 'Search by title or description...',
+                prefixIcon: const Icon(Icons.search),
+                suffixIcon: _searchController.text.isNotEmpty
+                    ? IconButton(
+                        icon: const Icon(Icons.clear),
+                        onPressed: () {
+                          _searchController.clear();
+                          // Forzar búsqueda vacía
+                          context.read<ReportListCubit>().search('');
+                        },
+                      )
+                    : null,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(30),
+                  borderSide: BorderSide.none,
+                ),
+                filled: true,
+                fillColor: Colors.grey[200],
+              ),
+            ),
+          ),
+        ),
+      ),
+      body: BlocBuilder<ReportListCubit, ReportListState>(
+        builder: (context, state) {
+          if (state is ReportListLoading) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is ReportListError) {
+            return Center(child: Text('Error: ${state.message}'));
+          } else if (state is ReportListLoaded) {
+            final reports = state.reports;
+            if (reports.isEmpty) {
+              return const Center(
+                child: Text('No reports found.'),
+              );
+            }
+            return ListView.builder(
+              itemCount: reports.length,
+              itemBuilder: (context, index) {
+                final report = reports[index];
+                return ListTile(
+                  title: Text(report.title),
+                  subtitle: Text(report.description),
+                  onTap: () {
+                    // Navegar a detalle del reporte (opcional)
+                  },
+                );
+              },
+            );
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}

--- a/src/lib/features/reports/presentation/routes.dart
+++ b/src/lib/features/reports/presentation/routes.dart
@@ -1,8 +1,16 @@
 import 'package:go_router/go_router.dart';
 import 'package:src/features/reports/presentation/pages/inventory_stock_report_page.dart';
+//only for testing purposes
+import 'package:src/features/reports/presentation/pages/report_list_page_not_official.dart';
 
 var inventoryStockReportRoute = GoRoute(
   path: 'inventory-stock-summary',
   name: 'inventory_stock_report',
   builder: (context, state) => const InventoryStockReportPage(),
+);
+
+var reportListRoute = GoRoute(
+  path: 'reports',
+  name: 'reports_list',
+  builder: (context, state) => const ReportListPage(),
 );


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #139 and #420 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?

**Added local search (client-side filtering) to the inventory stock report page (#139)**
- Introduced ReportState with allItems, searchQuery.
- Converted _SearchBar to StatefulWidget with controller and clear button.
- Display empty state when no items match.

**Implemented full‑text search for the reports list (#420)**
- Created SupabaseReportRepository with fetchReports, searchReports, fetchReportById.
- Added ReportListCubit with debounced search (500ms).
- Built temporary test page ReportListPage to demonstrate search.
- Added Supabase migration: search_vector column, GIN index, and search_reports function.
- Registered dependencies in injection_dependencies.dart.
- Added route /home/reports for testing.
- Updated report_metrics.dart with proper fields (id, title, description, createdAt) and fromJson.

### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
#139: Improve usability on the inventory report page by allowing users to filter items from the search bar in real time.

#420: Provide efficient and accurate search on reports using PostgreSQL’s native full‑text capabilities, avoiding slow LIKE queries.

---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Branch is up to date with base branch

---

## 🧪 Testing (if applicable)
<!-- Describe how you tested these changes -->
### Test Steps:
**Local search (#139)**
1. Launch app, navigate to Inventory Stock Summary.
3. Type in the search bar at the bottom.
5. Verify items filter instantly by name, category, or status. 
7. Erase what you wrote to filter the item.
9. Search for a term that doesn’t match → empty state appears.

**Full‑text search (#420)**

1. Run SQL migrations in Supabase.
2. Insert test reports (with [TEST] tag).
3. From Inventory Stock Summary, tap the list icon in the app bar (temporary button).
4. Wait for reports list to load.
5. Type a term (e.g., inventory).
6. After 500ms, the list updates with matching reports.
7. Type multi‑word queries (e.g., revenue a); no syntax errors.
8. Clear the search → full list restored.
9. Empty state when no results.

### Test Results:
<!-- What was the outcome? -->

- All search features work as expected.
- No database errors.
- Debouncing prevents excessive calls.

---

## 📸 Screenshots/Videos (if applicable)
<!-- Add screenshots or videos demonstrating the changes -->
Issue #139 
<img width="438" height="918" alt="imagen" src="https://github.com/user-attachments/assets/75037cab-5124-4755-87af-d86d9f992b65" />


Issue #420 
<img width="450" height="398" alt="imagen" src="https://github.com/user-attachments/assets/4d591f8e-72dc-4e13-a353-f399e8e53db6" />

---

## 👀 Reviewers
<!-- Tag team members for review -->
@LuisJCruz @Kay9876 
