### PR TITLE
[Lecture Topic Task]: Domain Events for Inventory Alerts and Restocking

### DIFF
--- a/docs/lecture-topic-tasks/domain-events-for-inventory-alerts-and-restocking.adoc
+++ b/docs/lecture-topic-tasks/domain-events-for-inventory-alerts-and-restocking.adoc
@@ -1,10 +1,5 @@
 = Lecture Topic Task: Domain Events for Inventory Alerts and Restocking
 
-// Traceability
-GitHub issue <<issue-322>> +
-Label: Lecture Topic Task (Team 2) +
-Related docs: <<alert-states>>, <<alert-seq>>
-
 == Objective
 
 Identify and document *domain events* for the Alerts & Restock slice of the Home Inventory system. A domain event is something meaningful that *already happened* in the domain (past tense, business-significant), which other parts of the system may react to—for example by creating alerts, updating read models, or suggesting grocery items. The notion aligns with event-oriented modeling in domain-driven design <<evans-ddd>>.


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue

Closes #322 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Added docs/lecture-topic-tasks/domain-events-for-inventory-alerts-and-restocking.adoc: domain events for Alerts & Restock (expiration, stock/restock, alert lifecycle), each with when and why.
- Added References with xrefs to existing alert docs, pointers to alerts_restock / core_inventory code, and a short DDD citation.


### Why was this change necessary?

Issue #322 requires documented domain events tied to alerts, expiration, and restocking. This file is that deliverable and aligns the team on names and triggers before deeper notification or integration work.


---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [ x ] Code follows project style guidelines
- [ x ] Self-review completed
- [ x ] Documentation updated
- [ x ] Branch is up to date with base branch

---

## 👀 Reviewers

@LuisJCruz 
@Kay9876 
@Solimar-Cruz 
