### PR TITLE
Implement Cubit for Core Inventory and Related Documentation

### DIFF
--- a/docs/4-specific-topics/core-inventory-state-management/core-inventory-state-management.adoc
+++ b/docs/4-specific-topics/core-inventory-state-management/core-inventory-state-management.adoc
@@ -1,0 +1,82 @@
+= Core Inventory State Management (Cubit)
+
+== 1. Objective and Chosen Approach
+
+The Core Inventory feature utilizes the **Cubit** pattern (via the `flutter_bloc` package) for state management. 
+
+**Why Cubit instead of Bloc?**
+Cubit was selected over the full Bloc pattern to minimize repetitive setup code (boilerplate). Since the Core Inventory primarily handles CRUD operations, using direct function calls within a Cubit provides a more concise implementation while maintaining the strict unidirectional data flow required by Clean Architecture.
+
+== 2. State Definitions
+
+The `InventoryState` abstract class defines the possible conditions of the Core Inventory data at any given time. UI components should react to these specific types:
+
+* `InventoryInitial`: The default state before any logic has been triggered.
+* `InventoryLoading`: Indicates an asynchronous operation (fetching, adding, updating, or deleting) is in progress. The UI should typically display a circular progress loading indicator during this state.
+* `InventoryLoaded`: Indicates a successful operation. This state carries the `InventoryEntity` payload containing the current stock and product mappings.
+* `InventoryError`: Indicates a failure in the domain or data layer. It carries a `String` message intended for user-facing error displays (e.g., Snackbars).
+
+== 3. Domain Layer Connectivity
+
+The `InventoryCubit` serves as the intermediary between the UI and the Domain layer. It does not know about the database (Supabase) but instead calls abstract Use Cases.
+
+[source,dart]
+----
+class InventoryCubit extends Cubit<InventoryState> {
+  final GetInventoryItems _getInventoryItems;
+  final AddInventoryItem _addInventoryItem;
+  final UpdateInventoryItem _updateInventoryItem;
+  final DeleteInventoryItem _deleteInventoryItem;
+
+  // Caches the owner context to simplify subsequent calls
+  int? _currentOwnerId;
+  
+  // ... functions calling use cases
+}
+----
+
+Note: The Cubit is responsible for maintaining the `ownerId` context. Once `loadInventory(ownerId)` is called, the Cubit stores that ID so that functions like `addStock` can refresh the data automatically without the UI needing to provide the owner ID again.
+
+== 4. Dependency Injection (GetIt)
+
+The Cubit and its entire dependency chain are registered in `src/lib/config/injection_dependencies.dart`. To prevent initialization crashes when starting the flutter app, the Data layer must be registered before the Domain and Presentation layers.
+
+[source,dart]
+----
+// Data Sources
+sl.registerSingleton<ProductSupabaseDataSource>(ProductSupabaseDataSource(sl()));
+sl.registerSingleton<InventorySupabaseDataSource>(InventorySupabaseDataSource(sl()));
+
+// Repositories
+sl.registerSingleton<ProductRepository>(ProductRepositoryImpl(sl()));
+sl.registerSingleton<InventoryRepository>(
+  InventoryRepositoryImpl(
+    sl<InventorySupabaseDataSource>(),
+    sl<ProductRepository>(),
+  ),
+);
+
+// Use Cases
+sl.registerSingleton<GetInventoryItems>(GetInventoryItems(sl()));
+sl.registerSingleton<AddInventoryItem>(AddInventoryItem(sl()));
+sl.registerSingleton<UpdateInventoryItem>(UpdateInventoryItem(sl()));
+sl.registerSingleton<DeleteInventoryItem>(DeleteInventoryItem(sl()));
+
+// Cubit Registration
+sl.registerFactory<InventoryCubit>(
+  () => InventoryCubit(
+    getInventoryItems: sl(),
+    addInventoryItem: sl(),
+    updateInventoryItem: sl(),
+    deleteInventoryItem: sl(),
+  ),
+);
+----
+
+== 5. Implementation Notes for UI Integration
+
+While the UI is a separate task, this Cubit is built to support standard `flutter_bloc` widgets:
+
+1. `BlocProvider`: Should wrap the Inventory screen to provide the `InventoryCubit` instance.
+2. `BlocBuilder`: Should be used to switch between the loading spinner, the error view, and the actual inventory list based on the states defined in Section 2.
+3. Methods: The UI should call `addStock`, `updateStock`, or `deleteStock` directly on the Cubit instance. These methods are asynchronous and handle state transitions internally.

--- a/src/lib/config/injection_dependencies.dart
+++ b/src/lib/config/injection_dependencies.dart
@@ -14,6 +14,17 @@ import 'package:src/features/reports/domain/repositories/supabase_report_reposit
 import 'package:src/features/reports/domain/repositories/report_repositories.dart';
 import 'package:src/features/reports/presentation/cubit/report_list_cubit.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:src/features/core_inventory/data/data_sources/inventory_supabase_datasource.dart';
+import 'package:src/features/core_inventory/data/data_sources/product_supabase_datasource.dart';
+import 'package:src/features/core_inventory/data/repositories/inventory_repository_impl.dart';
+import 'package:src/features/core_inventory/data/repositories/product_repository_impl.dart';
+import 'package:src/features/core_inventory/domain/repositories/inventory_repositories.dart';
+import 'package:src/features/core_inventory/domain/repositories/product_repository.dart';
+import 'package:src/features/core_inventory/domain/usecases/get_inventory_items.dart';
+import 'package:src/features/core_inventory/domain/usecases/add_inventory_item.dart';
+import 'package:src/features/core_inventory/domain/usecases/update_inventory_item.dart';
+import 'package:src/features/core_inventory/domain/usecases/delete_inventory_item.dart';
+import 'package:src/features/core_inventory/presentation/cubits/inventory_cubit.dart';
 
 final sl = GetIt.instance;
 
@@ -57,7 +68,39 @@ Future<void> initializeDependencies() async {
   /// they're not 100% standalone.
 
   /// Core Inventory
-  // ...
+  // Data Sources
+  sl.registerSingleton<ProductSupabaseDataSource>(
+    ProductSupabaseDataSource(sl()),
+  );
+  sl.registerSingleton<InventorySupabaseDataSource>(
+    InventorySupabaseDataSource(sl()),
+  );
+
+  // Repositories
+  sl.registerSingleton<ProductRepository>(ProductRepositoryImpl(sl()));
+
+  sl.registerSingleton<InventoryRepository>(
+    InventoryRepositoryImpl(
+      sl<InventorySupabaseDataSource>(),
+      sl<ProductRepository>(),
+    ),
+  );
+
+  // Usecases
+  sl.registerSingleton<GetInventoryItems>(GetInventoryItems(sl()));
+  sl.registerSingleton<AddInventoryItem>(AddInventoryItem(sl()));
+  sl.registerSingleton<UpdateInventoryItem>(UpdateInventoryItem(sl()));
+  sl.registerSingleton<DeleteInventoryItem>(DeleteInventoryItem(sl()));
+
+  // Cubit
+  sl.registerFactory<InventoryCubit>(
+    () => InventoryCubit(
+      getInventoryItems: sl(),
+      addInventoryItem: sl(),
+      updateInventoryItem: sl(),
+      deleteInventoryItem: sl(),
+    ),
+  );
 
   /// Alerts and Restock
   // ...

--- a/src/lib/features/core_inventory/presentation/cubits/inventory_cubit.dart
+++ b/src/lib/features/core_inventory/presentation/cubits/inventory_cubit.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../domain/usecases/get_inventory_items.dart';
+import '../../domain/usecases/add_inventory_item.dart';
+import '../../domain/usecases/update_inventory_item.dart';
+import '../../domain/usecases/delete_inventory_item.dart';
+import '../../domain/entities/stock.dart';
+import 'inventory_state.dart';
+
+class InventoryCubit extends Cubit<InventoryState> {
+  final GetInventoryItems _getInventoryItems;
+  final AddInventoryItem _addInventoryItem;
+  final UpdateInventoryItem _updateInventoryItem;
+  final DeleteInventoryItem _deleteInventoryItem;
+
+  int? _currentOwnerId;
+
+  InventoryCubit({
+    required GetInventoryItems getInventoryItems,
+    required AddInventoryItem addInventoryItem,
+    required UpdateInventoryItem updateInventoryItem,
+    required DeleteInventoryItem deleteInventoryItem,
+  })  : _getInventoryItems = getInventoryItems,
+        _addInventoryItem = addInventoryItem,
+        _updateInventoryItem = updateInventoryItem,
+        _deleteInventoryItem = deleteInventoryItem,
+        super(InventoryInitial());
+
+  /// Fetches the inventory for a given owner.
+  Future<void> loadInventory(int ownerId) async {
+    _currentOwnerId = ownerId;
+    emit(InventoryLoading());
+    try {
+      final inventory = await _getInventoryItems(ownerId);
+      emit(InventoryLoaded(inventory));
+    } catch (error) {
+      emit(InventoryError(error.toString()));
+    }
+  }
+
+  /// Adds a new stock item and refreshes the inventory.
+  Future<void> addStock(int inventoryId, int productId, StockEntity stock) async {
+    if (_currentOwnerId == null) {
+      emit(const InventoryError("Cannot add stock: Owner ID is unknown."));
+      return;
+    }
+    emit(InventoryLoading());
+    try {
+      await _addInventoryItem(inventoryId, productId, stock);
+      await loadInventory(_currentOwnerId!); // Refresh data
+    } catch (error) {
+      emit(InventoryError(error.toString()));
+    }
+  }
+
+  /// Updates an existing stock item and refreshes the inventory.
+  Future<void> updateStock(int inventoryId, int productId, StockEntity stock) async {
+    if (_currentOwnerId == null) {
+      emit(const InventoryError("Cannot update stock: Owner ID is unknown."));
+      return;
+    }
+    emit(InventoryLoading());
+    try {
+      await _updateInventoryItem(inventoryId, productId, stock);
+      await loadInventory(_currentOwnerId!); // Refresh data
+    } catch (error) {
+      emit(InventoryError(error.toString()));
+    }
+  }
+
+  /// Deletes a stock item and refreshes the inventory.
+  Future<void> deleteStock(int inventoryId, int productId, int stockId) async {
+    if (_currentOwnerId == null) {
+      emit(const InventoryError("Cannot delete stock: Owner ID is unknown."));
+      return;
+    }
+    emit(InventoryLoading());
+    try {
+      await _deleteInventoryItem(inventoryId, productId, stockId);
+      await loadInventory(_currentOwnerId!); // Refresh data
+    } catch (error) {
+      emit(InventoryError(error.toString()));
+    }
+  }
+}

--- a/src/lib/features/core_inventory/presentation/cubits/inventory_state.dart
+++ b/src/lib/features/core_inventory/presentation/cubits/inventory_state.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/inventory.dart';
+
+abstract class InventoryState extends Equatable {
+  const InventoryState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class InventoryInitial extends InventoryState {}
+
+class InventoryLoading extends InventoryState {}
+
+class InventoryLoaded extends InventoryState {
+  final InventoryEntity inventory;
+  const InventoryLoaded(this.inventory);
+
+  @override
+  List<Object?> get props => [inventory];
+}
+
+class InventoryError extends InventoryState {
+  final String message;
+  const InventoryError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   intl: ^0.20.2
   pdf: ^3.11.2
   printing: ^5.14.0
+  equatable: ^2.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #279 & #438 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
**Implementation**
- Implemented `InventoryCubit` and `InventoryState` to handle the core CRUD state management for the inventory.
- Created and wired up the Domain Use Cases (`GetInventoryItems`, `AddInventoryItem`, `UpdateInventoryItem`, `DeleteInventoryItem`).
- Configured the Data Layer repositories (`InventoryRepositoryImpl`, `ProductRepositoryImpl`) and their respective Supabase data sources in the 'injections_dependencies.dart' file
- Updated `injection_dependencies.dart` to correctly register the entire Core Inventory dependency chain.

**Documentation**
- Created `core_inventory_state_management.adoc` to document the Cubit architecture for the Core Inventory feature.
- Documented the 4 states (`InventoryInitial`, `InventoryLoading`, `InventoryLoaded`, `InventoryError`).
- Documented the Clean Architecture boundary between the Cubit and the Domain Use Cases, including the caching use of `ownerId`.
- Detailed the required `GetIt` Dependency Injection sequence (Data Sources -> Repositories -> Use Cases -> Cubit)
- Added a small technical guide for future UI integration (usage of `BlocProvider` and `BlocBuilder`).

### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
This PR establishes the underlying logic for the Core Inventory feature. By using `Cubit`, we help maintain a Clean Architecture, ensuring the future UI layer is completely separate from Supabase and only interacts with abstract domain logic. 

The included documentation provides a short description for the UI team, explaining how to trigger state changes and listen to inventory updates via `BlocProvider` and `BlocBuilder` without needing to reverse-engineer the Cubit logic.

---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
- [ ] Branch is up to date with base branch

---

## 👀 Reviewers
<!-- Tag team members for review -->
@kevgom018 
