### PR TITLE
Merge & normalize schema + add week 2 & 3 reports

### DIFF
--- a/.idea/caches/deviceStreaming.xml
+++ b/.idea/caches/deviceStreaming.xml
@@ -209,6 +209,18 @@
           <option name="screenY" value="2340" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a15xtfn" />
+          <option name="id" value="a15xtfn" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A15 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="35" />
           <option name="brand" value="samsung" />
           <option name="codename" value="a16" />
@@ -237,6 +249,18 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="a16x" />
           <option name="id" value="a16x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="A16 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a16xeea" />
+          <option name="id" value="a16xeea" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="A16 5G" />
@@ -425,6 +449,18 @@
           <option name="screenY" value="3088" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b5qsqw" />
+          <option name="id" value="b5qsqw" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Flip 5" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="748" />
+          <option name="screenY" value="720" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="b6q" />
@@ -433,6 +469,18 @@
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy Z Flip 6" />
           <option name="screenDensity" value="340" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2640" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b6qsqw" />
+          <option name="id" value="b6qsqw" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Flip 6" />
+          <option name="screenDensity" value="480" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2640" />
         </PersistentDeviceSelectionData>
@@ -767,6 +815,18 @@
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="motorola" />
+          <option name="codename" value="fogorow" />
+          <option name="id" value="fogorow" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g24" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1612" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
           <option name="codename" value="fogos" />
           <option name="id" value="fogos" />
           <option name="labId" value="google" />
@@ -811,6 +871,18 @@
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="gnevan" />
+          <option name="id" value="gnevan" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g stylus (2023)" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
@@ -1197,6 +1269,18 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="1856" />
           <option name="screenY" value="2160" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="r0qcsx" />
+          <option name="id" value="r0qcsx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="S22" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="30" />

--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/docs/2-descriptive/implementation/software-design/Team2-FinalizedSchema.adoc
+++ b/docs/2-descriptive/implementation/software-design/Team2-FinalizedSchema.adoc
@@ -1,0 +1,433 @@
+= Team 2 Canonical Supabase Schema
+:toc:
+:toclevels: 2
+
+== Purpose
+This document defines the merged and normalized Supabase schema for Team 2.
+
+It unifies the previously proposed work for:
+
+- inventory management
+- stock-level tracking
+- stock history
+- notifications and alerts
+- automated sweep audit logging
+
+This schema is based on the existing Team 2 documentation and the current code structure for automated expiration and stock checks.
+
+== Core Design Decision
+The current code checks expiration and stock status on individual `StockEntity` objects, not only on a single flat inventory item record.
+
+Because of that, the schema should separate:
+
+- `inventory_items`: the logical item
+- `stock_entries`: the concrete stock records for that item
+- `stock_changes`: the history of adjustments to stock records
+- `notifications`: user-facing alerts
+- `sweep_runs`: audit log for automated background checks
+
+This keeps the schema normalized and aligned with the implementation.
+
+== Source of Truth for Users
+This schema uses Supabase Auth as the user source of truth:
+
+- `auth.users`
+
+No duplicate custom users table should be created for Team 2.
+
+== Canonical Tables
+
+=== 1. inventory_items
+Represents the logical inventory item definition.
+
+Examples:
+- Milk
+- Eggs
+- Rice
+
+[cols="1,1,3",options="header"]
+|===
+| Field | Type | Description
+
+| id | uuid (PK) | Unique inventory item identifier
+| owner_user_id | uuid (FK -> auth.users.id) | User who owns the item
+| name | text | Item name
+| category | text (nullable) | Optional category
+| threshold | integer | Low-stock threshold used by alert logic
+| created_at | timestamptz | When the item was created
+| updated_at | timestamptz | Last update timestamp
+|===
+
+=== 2. stock_entries
+Represents individual stock records belonging to an inventory item.
+
+This table is needed because the code checks expiration and quantity at the stock level. A single inventory item may have multiple stock entries with different expiration dates.
+
+Examples:
+- Milk carton bought on Monday, expires Friday
+- Milk carton bought on Wednesday, expires next Tuesday
+
+[cols="1,1,3",options="header"]
+|===
+| Field | Type | Description
+
+| id | uuid (PK) | Unique stock entry identifier
+| inventory_item_id | uuid (FK -> inventory_items.id) | Parent inventory item
+| quantity | integer | Quantity for this stock entry
+| expiration_date | date (nullable) | Expiration date for this stock entry
+| is_expired | boolean | Derived expired state
+| is_near_expiration | boolean | Derived near-expiration state
+| is_low_stock | boolean | Derived low-stock state if needed at stock level
+| created_at | timestamptz | When the stock entry was created
+| updated_at | timestamptz | Last update timestamp
+|===
+
+=== 3. stock_changes
+Tracks quantity adjustments over time.
+
+This preserves history without mixing current state and past events.
+
+[cols="1,1,3",options="header"]
+|===
+| Field | Type | Description
+
+| id | uuid (PK) | Unique stock change identifier
+| stock_entry_id | uuid (FK -> stock_entries.id) | Related stock entry
+| quantity_change | integer | Positive or negative adjustment
+| reason | text | Reason for the change
+| changed_at | timestamptz | When the change occurred
+|===
+
+=== 4. notifications
+Stores in-app notifications for alerts and inventory-related events.
+
+This follows the Team 2 notifications design with enum-based type, status, and priority tracking. :contentReference[oaicite:2]{index=2}
+
+[cols="1,1,3",options="header"]
+|===
+| Field | Type | Description
+
+| id | uuid (PK) | Unique notification identifier
+| recipient_user_id | uuid (FK -> auth.users.id) | Recipient user
+| inventory_item_id | uuid (nullable, FK -> inventory_items.id) | Optional related inventory item
+| stock_entry_id | uuid (nullable, FK -> stock_entries.id) | Optional related stock entry
+| type | notification_type | Notification category
+| title | text | Notification title
+| message | text | Notification body
+| priority_level | notification_priority | Notification severity
+| status | notification_status | Lifecycle state
+| created_at | timestamptz | Row creation timestamp
+| triggered_at | timestamptz | When the alert condition occurred
+| expires_at | timestamptz (nullable) | Optional expiration timestamp
+| is_active | boolean | Soft enable/disable flag
+|===
+
+=== 5. sweep_runs
+Stores audit records for automated daily sweep executions.
+
+This aligns with the daily sweep architecture, which requires one run record per attempt with counts, status, and error summary. :contentReference[oaicite:3]{index=3}
+
+[cols="1,1,3",options="header"]
+|===
+| Field | Type | Description
+
+| id | uuid (PK) | Unique sweep run identifier
+| started_at | timestamptz | When the run started
+| completed_at | timestamptz (nullable) | When the run completed
+| status | text | Run status: started, success, failed, partial
+| items_scanned | integer | Number of stock entries checked
+| expired_flagged_count | integer | Number of expired stock entries found
+| near_expiration_count | integer | Number of near-expiration stock entries found
+| low_stock_flagged_count | integer | Number of low-stock items or entries found
+| out_of_stock_count | integer | Number of out-of-stock items or entries found
+| error_summary | text (nullable) | Error details if failed
+| trigger_source | text | Source of run: cron, manual, retry
+| run_scope | jsonb (nullable) | Optional scope metadata
+|===
+
+== Enum Types
+
+=== notification_type
+- LOW_STOCK
+- EXPIRING_SOON
+- EXPIRED
+- DUPLICATE_WARNING
+- SHARED_INVENTORY_UPDATE
+- OUT_OF_STOCK
+
+=== notification_status
+- UNREAD
+- READ
+- ARCHIVED
+- DISMISSED
+
+=== notification_priority
+- LOW
+- MEDIUM
+- HIGH
+- CRITICAL
+
+== Relationships
+- `auth.users (1) -> (N) inventory_items`
+- `inventory_items (1) -> (N) stock_entries`
+- `stock_entries (1) -> (N) stock_changes`
+- `auth.users (1) -> (N) notifications`
+- `inventory_items (1) -> (N) notifications`
+- `stock_entries (1) -> (N) notifications`
+- `sweep_runs` is independent audit infrastructure
+
+== Normalization Decisions
+
+=== Logical item vs stock record
+The schema separates logical items from physical stock records.
+
+- `inventory_items` stores the item definition
+- `stock_entries` stores the per-entry quantity and expiration data
+
+This matches the code better because expiration is evaluated on each stock entity.
+
+=== Current state vs history
+- current state lives in `stock_entries`
+- change history lives in `stock_changes`
+
+This avoids storing historical events inside current-state tables.
+
+=== Threshold placement
+`threshold` stays on `inventory_items`, because it describes the item-level restock rule rather than a single batch.
+
+=== Derived flags
+Derived fields are persisted on `stock_entries` so the UI and sweep worker do not need to recompute them every time. This matches the sweep architecture’s expectation of persisted derived status. :contentReference[oaicite:4]{index=4}
+
+=== Notifications
+Notifications remain their own table because they represent user-facing delivery/lifecycle data, not inventory state. This matches the Team 2 notification schema. :contentReference[oaicite:5]{index=5}
+
+== Recommended Supabase SQL
+
+[source,sql]
+----
+
+-- =========================================
+-- ENUM TYPES
+-- =========================================
+
+create type notification_type as enum (
+  'LOW_STOCK',
+  'EXPIRING_SOON',
+  'EXPIRED',
+  'DUPLICATE_WARNING',
+  'SHARED_INVENTORY_UPDATE',
+  'OUT_OF_STOCK'
+);
+
+create type notification_status as enum (
+  'UNREAD',
+  'READ',
+  'ARCHIVED',
+  'DISMISSED'
+);
+
+create type notification_priority as enum (
+  'LOW',
+  'MEDIUM',
+  'HIGH',
+  'CRITICAL'
+);
+
+-- =========================================
+-- INVENTORY ITEMS
+-- =========================================
+
+create table public.inventory_items (
+  id uuid primary key default gen_random_uuid(),
+
+  owner_user_id uuid not null
+    references auth.users(id)
+    on delete cascade,
+
+  name text not null,
+  category text null,
+
+  threshold integer not null default 0
+    check (threshold >= 0),
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- =========================================
+-- STOCK ENTRIES
+-- =========================================
+
+create table public.stock_entries (
+  id uuid primary key default gen_random_uuid(),
+
+  inventory_item_id uuid not null
+    references public.inventory_items(id)
+    on delete cascade,
+
+  quantity integer not null default 0
+    check (quantity >= 0),
+
+  expiration_date date null,
+
+  is_expired boolean not null default false,
+  is_near_expiration boolean not null default false,
+  is_low_stock boolean not null default false,
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- =========================================
+-- STOCK CHANGES
+-- =========================================
+
+create table public.stock_changes (
+  id uuid primary key default gen_random_uuid(),
+
+  stock_entry_id uuid not null
+    references public.stock_entries(id)
+    on delete cascade,
+
+  quantity_change integer not null,
+  reason text not null,
+
+  changed_at timestamptz not null default now()
+);
+
+-- =========================================
+-- NOTIFICATIONS
+-- =========================================
+
+create table public.notifications (
+  id uuid primary key default gen_random_uuid(),
+
+  recipient_user_id uuid not null
+    references auth.users(id)
+    on delete cascade,
+
+  inventory_item_id uuid null
+    references public.inventory_items(id)
+    on delete set null,
+
+  stock_entry_id uuid null
+    references public.stock_entries(id)
+    on delete set null,
+
+  type notification_type not null,
+  title text not null,
+  message text not null,
+
+  priority_level notification_priority not null default 'MEDIUM',
+  status notification_status not null default 'UNREAD',
+
+  created_at timestamptz not null default now(),
+  triggered_at timestamptz not null default now(),
+  expires_at timestamptz null,
+
+  is_active boolean not null default true
+);
+
+-- =========================================
+-- SWEEP RUNS
+-- =========================================
+
+create table public.sweep_runs (
+  id uuid primary key default gen_random_uuid(),
+
+  started_at timestamptz not null default now(),
+  completed_at timestamptz null,
+
+  status text not null
+    check (status in ('started', 'success', 'failed', 'partial')),
+
+  items_scanned integer not null default 0
+    check (items_scanned >= 0),
+
+  expired_flagged_count integer not null default 0
+    check (expired_flagged_count >= 0),
+
+  near_expiration_count integer not null default 0
+    check (near_expiration_count >= 0),
+
+  low_stock_flagged_count integer not null default 0
+    check (low_stock_flagged_count >= 0),
+
+  out_of_stock_count integer not null default 0
+    check (out_of_stock_count >= 0),
+
+  error_summary text null,
+  trigger_source text not null default 'cron',
+  run_scope jsonb null
+);
+
+-- =========================================
+-- INDEXES
+-- =========================================
+
+create index idx_inventory_items_owner
+  on public.inventory_items(owner_user_id);
+
+create index idx_stock_entries_inventory_item
+  on public.stock_entries(inventory_item_id);
+
+create index idx_stock_entries_expiration_date
+  on public.stock_entries(expiration_date);
+
+create index idx_stock_entries_is_expired
+  on public.stock_entries(is_expired);
+
+create index idx_stock_entries_is_near_expiration
+  on public.stock_entries(is_near_expiration);
+
+create index idx_stock_entries_is_low_stock
+  on public.stock_entries(is_low_stock);
+
+create index idx_stock_changes_stock_entry
+  on public.stock_changes(stock_entry_id);
+
+create index idx_stock_changes_changed_at
+  on public.stock_changes(changed_at desc);
+
+create index idx_notifications_recipient_created
+  on public.notifications(recipient_user_id, created_at desc);
+
+create index idx_notifications_recipient_status
+  on public.notifications(recipient_user_id, status);
+
+create index idx_notifications_inventory_item
+  on public.notifications(inventory_item_id);
+
+create index idx_notifications_stock_entry
+  on public.notifications(stock_entry_id);
+
+create index idx_notifications_type
+  on public.notifications(type);
+
+create index idx_sweep_runs_started_at
+  on public.sweep_runs(started_at desc);
+
+-- =========================================
+-- UPDATED_AT TRIGGER
+-- =========================================
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger trg_inventory_items_updated_at
+before update on public.inventory_items
+for each row
+execute function public.set_updated_at();
+
+create trigger trg_stock_entries_updated_at
+before update on public.stock_entries
+for each row
+execute function public.set_updated_at();
+----

--- a/docs/project-management/weekly-reports/milestone-2/week-2/team-2.adoc
+++ b/docs/project-management/weekly-reports/milestone-2/week-2/team-2.adoc
@@ -1,0 +1,63 @@
+= Milestone 2 - Week 2: Alerts & Restock Weekly Report
+:toc:
+
+== What the team accomplished this week
+
+This week Team 2 focused on strengthening the conceptual and structural foundation of the Alerts & Restock system.
+
+The team worked on documenting important domain-level concerns that affect the design of the feature, especially around competing goals and derived requirements. In parallel, implementation planning continued through schema design, stock movement tracking, and UI-related tasks that support future integration of alerts and notifications.
+
+Documentation was also expanded to better reflect the work completed and to keep the system design aligned across tasks.
+
+== Tasks completed / Issues closed
+
+The following tasks were completed and approved this week:
+
+* *Identify & Document Competing Goals + Derived Requirements*  
+  Completed documentation analyzing important tradeoffs and requirements that shape the Alerts & Restock system.
+
+* *Alerts & Restock System Documentation Updates*  
+  Documentation updates were added along with the completed tasks to improve clarity and maintain alignment across the feature.
+
+== What is currently in progress
+
+The team is currently working on the following tasks:
+
+* *Merge & Normalize Supabase Database Schemas Team 2*  
+  Consolidating previous schema work into one consistent database structure for the feature.
+
+* *Implement Inventory Stock Movement Tracking*  
+  Developing support for tracking inventory quantity changes over time.
+
+* *Modeling User UI Interactions as "Biddable" Domain Behaviors*  
+  Continuing domain modeling work related to user interactions in the Alerts interface.
+
+* *Develop Alerts Feed UI with Swipe Actions & Empty States*  
+  Continuing UI development for the alerts feed experience.
+
+== Blockers or challenges
+
+Some challenges involved coordinating multiple efforts at the same time, especially across documentation, schema design, and implementation planning.
+
+Because several tasks are closely related, care was needed to keep terminology, structure, and design decisions consistent across the system.
+
+== Plans for next week
+
+Next week the team plans to:
+
+* Continue progressing the open development and lecture topic tasks
+* Advance the Supabase schema consolidation work
+* Continue work on stock movement tracking
+* Refine the alerts feed UI
+* Keep documentation updated alongside implementation progress
+
+== Documentation Links
+
+Related issues:
+
+* #399 - Identify & Document Competing Goals + Derived Requirements
+* #297 - Merge & Normalize Supabase Database Schemas Team 2
+* #313 - Implement Inventory Stock Movement Tracking
+* #306 - Modeling User UI Interactions as "Biddable" Domain Behaviors
+* #304 - Develop Alerts Feed UI with Swipe Actions & Empty States
+

--- a/docs/project-management/weekly-reports/milestone-2/week-3/team-2.adoc
+++ b/docs/project-management/weekly-reports/milestone-2/week-3/team-2.adoc
@@ -1,0 +1,67 @@
+= Milestone 2 - Week 3: Alerts & Restock Weekly Report
+:toc:
+
+== What the team accomplished this week
+
+This week Team 2 focused on validating and refining the domain model for the Home Inventory system as it relates to Alerts & Restock.
+
+The team completed lecture topic work centered on dimensionality, validation, and verification of the domain model. These tasks helped strengthen the conceptual accuracy of the feature and improved confidence that the system behavior is being modeled correctly.
+
+At the same time, work continued on ongoing development tasks related to the schema, stock tracking, and alerts UI. Documentation was also updated to reflect the completed work.
+
+== Tasks completed / Issues closed
+
+The following tasks were completed and approved this week:
+
+* *Dimensionality of Domain Phenomena in the Home Inventory System*  
+  Completed documentation and analysis of the relevant domain phenomena for the system.
+
+* *Domain Validation and Verification of the Home Inventory Model*  
+  Completed validation and verification work to ensure the domain model is consistent and meaningful.
+
+* *Alerts & Restock System Documentation Updates*  
+  Documentation updates were added along with the completed tasks to improve clarity and maintain alignment across the feature.
+
+== What is currently in progress
+
+The team is currently working on the following tasks:
+
+* *Merge & Normalize Supabase Database Schemas Team 2*  
+  Continuing the process of unifying and refining the database structure.
+
+* *Implement Inventory Stock Movement Tracking*  
+  Continuing implementation of quantity movement tracking for inventory items.
+
+* *Modeling User UI Interactions as "Biddable" Domain Behaviors*  
+  Continuing domain behavior modeling related to the user interface.
+
+* *Develop Alerts Feed UI with Swipe Actions & Empty States*  
+  Continuing development of the alerts feed user experience.
+
+== Blockers or challenges
+
+The main challenge this week was maintaining consistency between the domain modeling work and the implementation tasks that are still ongoing.
+
+Since schema design, stock tracking, and alerts UI all depend on a clear understanding of the domain, the team needed to ensure that newly completed conceptual work remained aligned with current development efforts.
+
+== Plans for next week
+
+Next week the team plans to:
+
+* Continue open development tasks for Alerts & Restock
+* Apply domain modeling insights to the ongoing schema and tracking work
+* Continue improving the alerts feed UI
+* Maintain documentation updates alongside implementation progress
+* Prepare the system for further integration work
+
+== Documentation Links
+
+Related issues:
+
+* #352 - Dimensionality of Domain Phenomena in the Home Inventory System
+* #351 - Domain Validation and Verification of the Home Inventory Model
+* #297 - Merge & Normalize Supabase Database Schemas Team 2
+* #313 - Implement Inventory Stock Movement Tracking
+* #306 - Modeling User UI Interactions as "Biddable" Domain Behaviors
+* #304 - Develop Alerts Feed UI with Swipe Actions & Empty States
+


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
Closes #403  
Closes #297  

---

## 📝 Description

### What changed?
- Created a **canonical Supabase schema** for Team 2 including:
  - `inventory_items`
  - `stock_entries`
  - `stock_changes`
  - `notifications`
  - `sweep_runs`
  - notification enum types
- Merged and normalized previous schema drafts into a single consistent structure
- Defined proper relationships and foreign keys between tables
- Aligned schema with:
  - Alerts & Restock logic (expiration + stock checks)
  - Notifications system
  - Daily sweep architecture
- Added **Week 2 and Week 3 Alerts & Restock weekly reports** in AsciiDoc format

### Why was this change necessary?
- Previous schema drafts had inconsistencies and overlapping concepts
- Needed a **single canonical schema** for Team 2 to ensure consistency across development
- Supports current implementation logic (stock tracking, expiration checks, notifications)
- Improves maintainability and reduces redundancy
- Weekly reports are required for milestone tracking and Scrum preparation

---

## ✅ Checklist
- [x] Code follows project style guidelines  
- [x] Self-review completed  
- [x] Documentation updated  
- [x] Branch is up to date with base branch  

---

## 🧪 Testing (if applicable)

### Test Steps:
1. Reviewed schema structure and relationships
2. Verified alignment with Alerts & Restock logic (stock + expiration checks)
3. Checked AsciiDoc formatting for weekly reports

### Test Results:
- Schema is consistent and properly normalized
- Relationships and foreign keys are correctly defined
- Documentation renders correctly and matches implementation

---

## 📸 Screenshots/Videos (if applicable)

---

## 👀 Reviewers
@LuisJCruz  
@Kay9876  

