### PR TITLE
Loading states and error states implemented for Reports Section

### DIFF
--- a/src/lib/features/reports/domain/entities/inventory_item.dart
+++ b/src/lib/features/reports/domain/entities/inventory_item.dart
@@ -1,0 +1,39 @@
+class InventoryItem {
+  final String id;
+  final String name;
+  final String category;
+  final int quantity;
+  final String status;
+  final DateTime createdAt;
+
+  const InventoryItem({
+    required this.id,
+    required this.name,
+    required this.category,
+    required this.quantity,
+    required this.status,
+    required this.createdAt,
+  });
+
+  /// Factory for creating from JSON (when real API is ready)
+  factory InventoryItem.fromJson(Map<String, dynamic> json) {
+    return InventoryItem(
+      id: json['id'],
+      name: json['name'],
+      category: json['category'],
+      quantity: json['quantity'],
+      status: json['status'],
+      createdAt: DateTime.parse(json['created_at']),
+    );
+  }
+
+  /// Convert to JSON (if needed)
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'name': name,
+    'category': category,
+    'quantity': quantity,
+    'status': status,
+    'created_at': createdAt.toIso8601String(),
+  };
+}

--- a/src/lib/features/reports/domain/repositories/inventory_repository.dart
+++ b/src/lib/features/reports/domain/repositories/inventory_repository.dart
@@ -1,0 +1,15 @@
+import '../entities/inventory_item.dart';
+
+abstract class InventoryRepository {
+  /// Fetch inventory items based on filters.
+  /// 
+  /// - [startDate] / [endDate] filter items by creation date.
+  /// - [page] determines which category page is requested (0 or 1).
+  /// - [searchQuery] filters by name, category, or status (case‑insensitive).
+  Future<List<InventoryItem>> fetchItems({
+    required DateTime startDate,
+    required DateTime endDate,
+    required int page,
+    required String searchQuery,
+  });
+}

--- a/src/lib/features/reports/presentation/cubit/inventory_stock_report_cubit.dart
+++ b/src/lib/features/reports/presentation/cubit/inventory_stock_report_cubit.dart
@@ -1,4 +1,4 @@
-//TO DO: REPLACE HARDCODED DATA WITH DATA PULLED FROM BACKEND (SEE LINE 23)
+// TO DO: REPLACE HARDCODED DATA WITH DATA PULLED FROM BACKEND (SEE LINE 47)
 
 import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -12,33 +12,74 @@ class InventoryStockReportCubit extends Cubit<InventoryStockReportState> {
   final ReportFilterValidator _validator = ReportFilterValidator();
   Timer? _debounceTimer;
 
+  // For simulating network delay (can be removed later)
+  static const bool _simulateError = false; // set to true to test error state
+
   InventoryStockReportCubit()
       : super(InventoryStockReportState(
-          filters: ReportFilters(  //Removed 'const' keyword
+          filters: ReportFilters(
             startDate: DateTime(2026, 3, 9),
             endDate: DateTime(2026, 3, 15),
             page: 0,
             searchQuery: '',
           ),
-//TO DO: REPLACE HARDCODED DATA WITH DATA PULLED FROM BACKEND (potentially also update line 18-19 dates)
-          allItems: const [
-            ItemData('Eggs', 'Food', 18, 'OK'),
-            ItemData('Beans (cans)', 'Food', 15, 'OK'),
-            ItemData('Rice (bags)', 'Food', 1, 'LOW'),
-            ItemData('Meat (packs)', 'Food', 9, 'OK'),
-            ItemData('Cereal (boxes)', 'Food', 0, 'OUT OF STOCK'),
-            ItemData('Bananas', 'Food', 2, 'LOW'),
-            ItemData('Batteries AA', 'Utilities', 25, 'OK'),
-            ItemData('Batteries AAA', 'Utilities', 19, 'OK'),
-            ItemData('Advil (pills)', 'Medicine', 1, 'LOW'),
-            ItemData('Throat lozenges', 'Medicine', 19, 'OK'),
-            ItemData('Laundry detergent', 'Laundry', 0, 'OUT OF STOCK'),
-          ],
+          allItems: const [], // start empty; will be filled by loadInventoryData
+          isLoading: true,    // show spinner immediately
         )) {
     loadFavorites();
     _validateFiltersDebounced();
+    loadInventoryData(); // load initial data
   }
 
+  // ---------- Data fetching (simulated) ----------
+  /// Simulates an asynchronous fetch of inventory items.
+  /// Replace this with a real Supabase call later.
+  Future<List<ItemData>> _fetchInventoryData() async {
+    // Simulate network delay (500-1000ms)
+    await Future.delayed(const Duration(milliseconds: 800));
+
+    // Optional: simulate error for testing
+    if (_simulateError) {
+      throw Exception('Simulated network failure');
+    }
+
+    // Return the hardcoded demo data
+    //TO DO: REPLACE HARDCODED DATA WITH DATA PULLED FROM BACKEND (potentially also update line 21-22 dates)
+    return const [
+      ItemData('Eggs', 'Food', 18, 'OK'),
+      ItemData('Beans (cans)', 'Food', 15, 'OK'),
+      ItemData('Rice (bags)', 'Food', 1, 'LOW'),
+      ItemData('Meat (packs)', 'Food', 9, 'OK'),
+      ItemData('Cereal (boxes)', 'Food', 0, 'OUT OF STOCK'),
+      ItemData('Bananas', 'Food', 2, 'LOW'),
+      ItemData('Batteries AA', 'Utilities', 25, 'OK'),
+      ItemData('Batteries AAA', 'Utilities', 19, 'OK'),
+      ItemData('Advil (pills)', 'Medicine', 1, 'LOW'),
+      ItemData('Throat lozenges', 'Medicine', 19, 'OK'),
+      ItemData('Laundry detergent', 'Laundry', 0, 'OUT OF STOCK'),
+    ];
+  }
+
+  /// Load inventory data from the (simulated) source.
+  /// Sets loading state, fetches data, and updates state or shows error.
+  Future<void> loadInventoryData() async {
+  // No guard – allow fetching even if already loading
+  emit(state.copyWith(isLoading: true, errorMessage: null));
+
+  try {
+    final items = await _fetchInventoryData();
+    emit(state.copyWith(allItems: items, isLoading: false));
+    _validateFilters();
+  } catch (e) {
+    emit(state.copyWith(
+      allItems: const [],
+      isLoading: false,
+      errorMessage: 'Unable to load inventory data. Please check your connection and try again.',
+    ));
+  }
+}
+
+  // ---------- Filter methods ----------
   void setStartDate(DateTime date) => _updateFilters(state.filters.copyWith(startDate: date));
   void setEndDate(DateTime date) => _updateFilters(state.filters.copyWith(endDate: date));
   void setPage(int page) => _updateFilters(state.filters.copyWith(page: page));
@@ -46,20 +87,27 @@ class InventoryStockReportCubit extends Cubit<InventoryStockReportState> {
 
   void _updateFilters(ReportFilters newFilters) {
     emit(state.copyWith(filters: newFilters));
+    loadInventoryData(); // refetch data with new filters
     _validateFiltersDebounced();
+  }
+
+  // ---------- Validation ----------
+  void _validateFilters() async {
+    final result = await _validator.validate(
+      state.filters,
+      totalAvailableItems: state.allItems.length, // use loaded items count
+    );
+    emit(state.copyWith(validationResult: result));
   }
 
   void _validateFiltersDebounced() {
     _debounceTimer?.cancel();
-    _debounceTimer = Timer(const Duration(milliseconds: 500), () async {
-      final result = await _validator.validate(
-        state.filters,
-        totalAvailableItems: state.filteredItems.length,
-      );
-      emit(state.copyWith(validationResult: result));
+    _debounceTimer = Timer(const Duration(milliseconds: 500), () {
+      _validateFilters();
     });
   }
 
+  // ---------- Favorites (unchanged) ----------
   Future<void> loadFavorites() async {
     emit(state.copyWith(isLoadingFavorites: true, favoriteError: null));
     try {
@@ -100,6 +148,7 @@ class InventoryStockReportCubit extends Cubit<InventoryStockReportState> {
 
   void applyFavorite(ReportFavorite favorite) {
     emit(state.copyWith(filters: favorite.filters));
+    loadInventoryData(); // load data for the new filters
     _validateFiltersDebounced();
   }
 

--- a/src/lib/features/reports/presentation/cubit/inventory_stock_report_state.dart
+++ b/src/lib/features/reports/presentation/cubit/inventory_stock_report_state.dart
@@ -1,4 +1,4 @@
-//TO DO: REPLACE HARDCODED DATA WITH REAL DATA PULLED FROM BACKEND (SEE LINE 51)
+// TO DO: REPLACE HARDCODED DATA WITH REAL DATA PULLED FROM BACKEND (SEE LINE 57)
 
 import '../../domain/entities/report_filters.dart';
 import '../../domain/repositories/favorites_repository.dart';
@@ -26,6 +26,10 @@ class InventoryStockReportState {
   final bool isLoadingFavorites;
   final String? favoriteError;
 
+  // NEW: loading and error states for inventory data
+  final bool isLoading;
+  final String? errorMessage;
+
   const InventoryStockReportState({
     required this.filters,
     required this.allItems,
@@ -33,6 +37,8 @@ class InventoryStockReportState {
     this.validationResult,
     this.isLoadingFavorites = false,
     this.favoriteError,
+    this.isLoading = false,
+    this.errorMessage,
   });
 
   // No category filter – only search query
@@ -48,20 +54,20 @@ class InventoryStockReportState {
     return items;
   }
 
-//TO DO: REPLACE HARDCODED DATA HERE AND IN inventory_stock_report_cubit.dart
-List<CategoryData> get currentPageData {
-  // Return ALL categories for scrolling instead of pagination
-  return const [
-    CategoryData('Food', 44),
-    CategoryData('Kitchen', 20),
-    CategoryData('Cleaning', 38),
-    CategoryData('Hygiene', 24),
-    CategoryData('Bathroom', 30),
-    CategoryData('Utilities', 64),
-    CategoryData('Medicine', 20),
-    CategoryData('Laundry', 0),
-  ];
-}
+  // TO DO: REPLACE HARDCODED DATA HERE AND IN inventory_stock_report_cubit.dart
+  List<CategoryData> get currentPageData {
+    // Return ALL categories for scrolling instead of pagination
+    return const [
+      CategoryData('Food', 44),
+      CategoryData('Kitchen', 20),
+      CategoryData('Cleaning', 38),
+      CategoryData('Hygiene', 24),
+      CategoryData('Bathroom', 30),
+      CategoryData('Utilities', 64),
+      CategoryData('Medicine', 20),
+      CategoryData('Laundry', 0),
+    ];
+  }
 
   InventoryStockReportState copyWith({
     ReportFilters? filters,
@@ -70,6 +76,8 @@ List<CategoryData> get currentPageData {
     ValidationResult? validationResult,
     bool? isLoadingFavorites,
     String? favoriteError,
+    bool? isLoading,
+    String? errorMessage,
   }) {
     return InventoryStockReportState(
       filters: filters ?? this.filters,
@@ -78,6 +86,8 @@ List<CategoryData> get currentPageData {
       validationResult: validationResult ?? this.validationResult,
       isLoadingFavorites: isLoadingFavorites ?? this.isLoadingFavorites,
       favoriteError: favoriteError ?? this.favoriteError,
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: errorMessage ?? this.errorMessage,
     );
   }
 }

--- a/src/lib/features/reports/presentation/pages/expenditure_report_page.dart
+++ b/src/lib/features/reports/presentation/pages/expenditure_report_page.dart
@@ -1,4 +1,4 @@
-//TO DO: REPLACE HARDCODED DATA WITH DATA PULLED FROM BACKEND (SEE LINE 44)
+//TO DO: REPLACE HARDCODED DATA WITH DATA PULLED FROM BACKEND (SEE LINE 49)
 //Graph radius in widgets/dynamic_pie_chart.dart may require adjustment based on the amount of categories
 
 import 'dart:math' as math;
@@ -39,6 +39,10 @@ class ExpenditureState {
   final bool isLoadingFavorites;
   final String? favoriteError;
 
+  // NEW: loading and error states for expenditure data
+  final bool isLoading;
+  final String? errorMessage;
+
   ExpenditureState({
     DateTime? startDate,
     DateTime? endDate,
@@ -54,6 +58,8 @@ class ExpenditureState {
     this.favorites = const [],
     this.isLoadingFavorites = false,
     this.favoriteError,
+    this.isLoading = false,
+    this.errorMessage,
   })  : startDate = startDate ?? DateTime(2026, 3, 9),
         endDate   = endDate   ?? DateTime(2026, 3, 15);
 
@@ -63,17 +69,22 @@ class ExpenditureState {
   ExpenditureState copyWith({
     DateTime? startDate,
     DateTime? endDate,
+    List<ExpenditureCategory>? categories,
     List<ReportFavorite>? favorites,
     bool? isLoadingFavorites,
     String? favoriteError,
+    bool? isLoading,
+    String? errorMessage,
   }) {
     return ExpenditureState(
       startDate: startDate ?? this.startDate,
       endDate: endDate ?? this.endDate,
-      categories: categories,
+      categories: categories ?? this.categories,
       favorites: favorites ?? this.favorites,
       isLoadingFavorites: isLoadingFavorites ?? this.isLoadingFavorites,
       favoriteError: favoriteError ?? this.favoriteError,
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: errorMessage ?? this.errorMessage,
     );
   }
 }
@@ -81,12 +92,57 @@ class ExpenditureState {
 class ExpenditureCubit extends Cubit<ExpenditureState> {
   final FavoritesRepository _favoritesRepository = FavoritesRepository();
   
-  ExpenditureCubit() : super(ExpenditureState()) {
+  // Simulate error for testing (set to true to test error state)
+  static const bool _simulateError = false;
+
+  ExpenditureCubit() : super(ExpenditureState(isLoading: true)) {
     loadFavorites();
+    loadExpenditureData();
   }
 
-  void setStartDate(DateTime date) => emit(state.copyWith(startDate: date));
-  void setEndDate(DateTime date) => emit(state.copyWith(endDate: date));
+  // ---------- Data fetching (simulated) ----------
+  /// Simulates an asynchronous fetch of expenditure data.
+  /// Replace with real Supabase call later.
+  Future<List<ExpenditureCategory>> _fetchExpenditureData() async {
+    await Future.delayed(const Duration(milliseconds: 800));
+    if (_simulateError) {
+      throw Exception('Simulated network failure');
+    }
+    // Return hardcoded demo data
+    return const [
+      ExpenditureCategory(name: 'Food',      amount: 56.78, color: Color(0xFFF5A623)),
+      ExpenditureCategory(name: 'Kitchen',   amount: 45.87, color: Color(0xFF4ECDC4)),
+      ExpenditureCategory(name: 'Cleaning',  amount: 20.60, color: Color(0xFF4A90D9)),
+      ExpenditureCategory(name: 'Hygiene',   amount: 22.65, color: Color(0xFF7BC67A)),
+      ExpenditureCategory(name: 'Bathroom',  amount: 70.96, color: Color(0xFF7B68EE)),
+      ExpenditureCategory(name: 'Utilities', amount: 61.67, color: Color(0xFFF08080)),
+    ];
+  }
+
+  Future<void> loadExpenditureData() async {
+    emit(state.copyWith(isLoading: true, errorMessage: null));
+
+    try {
+      final categories = await _fetchExpenditureData();
+      emit(state.copyWith(categories: categories, isLoading: false));
+    } catch (e) {
+      emit(state.copyWith(
+        categories: const [],
+        isLoading: false,
+        errorMessage: 'Unable to load expenditure data. Please check your connection and try again.',
+      ));
+    }
+  }
+
+  void setStartDate(DateTime date) {
+    emit(state.copyWith(startDate: date));
+    loadExpenditureData();
+  }
+
+  void setEndDate(DateTime date) {
+    emit(state.copyWith(endDate: date));
+    loadExpenditureData();
+  }
 
   Future<void> loadFavorites() async {
     emit(state.copyWith(isLoadingFavorites: true, favoriteError: null));
@@ -128,6 +184,7 @@ class ExpenditureCubit extends Cubit<ExpenditureState> {
       startDate: favorite.filters.startDate,
       endDate: favorite.filters.endDate,
     ));
+    loadExpenditureData();
   }
 }
 
@@ -328,6 +385,50 @@ class _ExpenditureViewState extends State<_ExpenditureView> {
       ),
       body: BlocBuilder<ExpenditureCubit, ExpenditureState>(
         builder: (context, state) {
+          // Loading state
+          if (state.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          // Error state
+          if (state.errorMessage != null) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    state.errorMessage!,
+                    style: const TextStyle(color: Colors.red, fontSize: 16),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => context.read<ExpenditureCubit>().loadExpenditureData(),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppTheme.primaryColor,
+                    ),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          // Empty state (no categories after data loaded)
+          if (state.categories.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(32),
+                child: Text(
+                  'No expenditure data found for the selected period.',
+                  style: TextStyle(fontSize: 16, color: AppTheme.mutedText),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+
+          // Normal loaded state
           return Column(
             children: [
               Expanded(

--- a/src/lib/features/reports/presentation/pages/inventory_stock_report_page.dart
+++ b/src/lib/features/reports/presentation/pages/inventory_stock_report_page.dart
@@ -1,5 +1,5 @@
-//TO DO: REPLACE HARDCODED DATA THAT'S USED IN inventory_stock_report_cubit.dart AND
-//inventory_stock_report_state.dart, BOTH FILES IN THE CUBIT FOLDER SIBLING OF THE CURRENT PAGES ONE
+// TO DO: REPLACE HARDCODED DATA THAT'S USED IN inventory_stock_report_cubit.dart AND
+// inventory_stock_report_state.dart, BOTH FILES IN THE CUBIT FOLDER SIBLING OF THE CURRENT PAGES ONE
 
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -266,7 +266,7 @@ class _ReportViewState extends State<_ReportView> {
     }
   }
 
-  // ---------- Build ----------
+  // ---------- Build with Loading / Error / Empty States ----------
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -357,6 +357,50 @@ class _ReportViewState extends State<_ReportView> {
       ),
       body: BlocBuilder<InventoryStockReportCubit, InventoryStockReportState>(
         builder: (context, state) {
+          // --- Loading state ---
+          if (state.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          // --- Error state ---
+          if (state.errorMessage != null) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    state.errorMessage!,
+                    style: const TextStyle(color: Colors.red, fontSize: 16),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => context.read<InventoryStockReportCubit>().loadInventoryData(),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppTheme.primaryColor,
+                    ),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          // --- Empty state (data loaded but no items) ---
+          if (state.allItems.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(32),
+                child: Text(
+                  'No inventory items found for the selected filters.',
+                  style: TextStyle(fontSize: 16, color: Colors.black54),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+
+          // --- Normal loaded state ---
           return Column(
             children: [
               // Scrollable content (everything except the bottom search bar)
@@ -434,7 +478,7 @@ class _ReportViewState extends State<_ReportView> {
                   ),
                 ),
               ),
-              // Search bar with export button (sticky at bottom)
+              // Search bar with export button
               _SearchBar(onExport: () => _exportPdf(context, state)),
             ],
           );
@@ -510,7 +554,6 @@ class _DataTable extends StatelessWidget {
         children: [
           _header(),
           const Divider(height: 1),
-          // Removed Expanded and ListView - using simple Column with children
           Column(
             children: items.map((item) => _row(item)).toList(),
           ),

--- a/src/lib/features/reports/presentation/pages/item_usage_rates_page.dart
+++ b/src/lib/features/reports/presentation/pages/item_usage_rates_page.dart
@@ -1,4 +1,4 @@
-//TO DO: REPLACE HARDCODED DATA WITH DATA PULLED FROM BACKEND (SEE LINE 30)
+//TO DO: REPLACE HARDCODED DATA WITH DATA PULLED FROM BACKEND (SEE LINE 31)
 
 import 'dart:math' as math;
 import 'dart:typed_data';
@@ -6,6 +6,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:src/config/theme.dart';
 import '../../../../core/data/services/pdf_export_service.dart';
@@ -25,7 +26,7 @@ class _UsageCategory {
   });
 }
 
-// ======================== Static Sample Data ========================
+// ======================== Static Sample Data (will be replaced) ========================
 
 //TO DO: REPLACE HARDCODED DATA WITH BACKEND DATA
 const _kAllCategories = [
@@ -53,22 +54,134 @@ const _kDateRanges = [
   'Feb 2 - 8',
 ];
 
+// ======================== Cubit & State ========================
+
+class ItemUsageRatesState {
+  final String selectedDateRange;
+  final Set<String> selectedCategories;
+  final List<_UsageCategory> categories; // filtered based on selection
+  final List<double> chartPoints;
+  final List<String> chartDays;
+  final bool isLoading;
+  final String? errorMessage;
+
+  const ItemUsageRatesState({
+    required this.selectedDateRange,
+    required this.selectedCategories,
+    required this.categories,
+    required this.chartPoints,
+    required this.chartDays,
+    this.isLoading = false,
+    this.errorMessage,
+  });
+
+  ItemUsageRatesState copyWith({
+    String? selectedDateRange,
+    Set<String>? selectedCategories,
+    List<_UsageCategory>? categories,
+    List<double>? chartPoints,
+    List<String>? chartDays,
+    bool? isLoading,
+    String? errorMessage,
+  }) {
+    return ItemUsageRatesState(
+      selectedDateRange: selectedDateRange ?? this.selectedDateRange,
+      selectedCategories: selectedCategories ?? this.selectedCategories,
+      categories: categories ?? this.categories,
+      chartPoints: chartPoints ?? this.chartPoints,
+      chartDays: chartDays ?? this.chartDays,
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}
+
+class ItemUsageRatesCubit extends Cubit<ItemUsageRatesState> {
+  static const bool _simulateError = false; // set to true to test error state
+
+  ItemUsageRatesCubit()
+      : super(ItemUsageRatesState(
+          selectedDateRange: 'Mar 9 - 15',
+          selectedCategories: {
+            'Food', 'Kitchen', 'Cleaning', 'Hygiene',
+            'Bathroom', 'Utilities', 'Medicine', 'Laundry',
+          },
+          categories: _kAllCategories,
+          chartPoints: _kChartPoints,
+          chartDays: _kChartDays,
+          isLoading: true,
+        )) {
+    _loadData();
+  }
+
+  // Simulate async data fetch (replace with real Supabase call)
+  Future<void> _loadData() async {
+    emit(state.copyWith(isLoading: true, errorMessage: null));
+    await Future.delayed(const Duration(milliseconds: 800));
+    if (_simulateError) {
+      emit(state.copyWith(
+        isLoading: false,
+        errorMessage: 'Unable to load usage rates. Please check your connection and try again.',
+      ));
+      return;
+    }
+    // Use static data (future: fetch from backend)
+    final allCategories = _kAllCategories;
+    final filtered = allCategories
+        .where((c) => state.selectedCategories.contains(c.name))
+        .toList();
+    emit(state.copyWith(
+      categories: filtered,
+      isLoading: false,
+      errorMessage: null,
+    ));
+  }
+
+  void setDateRange(String range) {
+    emit(state.copyWith(selectedDateRange: range));
+    _loadData(); // In real implementation, fetch data for new date range
+  }
+
+  void toggleCategory(String category) {
+    final newSelection = Set<String>.from(state.selectedCategories);
+    if (newSelection.contains(category)) {
+      if (newSelection.length > 1) {
+        newSelection.remove(category);
+      }
+    } else {
+      newSelection.add(category);
+    }
+    emit(state.copyWith(selectedCategories: newSelection));
+    _loadData(); // Refetch filtered data (or filter client-side)
+  }
+
+  void retryLoad() {
+    _loadData();
+  }
+}
+
 // ======================== Page ========================
 
-class ItemUsageRatesPage extends StatefulWidget {
+class ItemUsageRatesPage extends StatelessWidget {
   const ItemUsageRatesPage({super.key});
 
   @override
-  State<ItemUsageRatesPage> createState() => _ItemUsageRatesPageState();
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => ItemUsageRatesCubit(),
+      child: const _ItemUsageRatesView(),
+    );
+  }
 }
 
-class _ItemUsageRatesPageState extends State<ItemUsageRatesPage> {
-  String _selectedDateRange = 'Mar 9 - 15';
-  final Set<String> _selectedCategories = {
-    'Food', 'Kitchen', 'Cleaning', 'Hygiene',
-    'Bathroom', 'Utilities', 'Medicine', 'Laundry',
-  };
+class _ItemUsageRatesView extends StatefulWidget {
+  const _ItemUsageRatesView();
 
+  @override
+  State<_ItemUsageRatesView> createState() => _ItemUsageRatesViewState();
+}
+
+class _ItemUsageRatesViewState extends State<_ItemUsageRatesView> {
   final TextEditingController _searchController = TextEditingController();
 
   // LayerLink anchors the overlay to the Filters button
@@ -93,7 +206,6 @@ class _ItemUsageRatesPageState extends State<ItemUsageRatesPage> {
   void _removeOverlay() {
     _overlayEntry?.remove();
     _overlayEntry = null;
-    // Don't call setState here — may be called during dispose
   }
 
   void _closeOverlay() {
@@ -112,7 +224,6 @@ class _ItemUsageRatesPageState extends State<ItemUsageRatesPage> {
 
   void _setOverlayState(String state) {
     setState(() => _overlayState = state);
-    // Rebuild the existing entry in place
     _overlayEntry?.markNeedsBuild();
   }
 
@@ -139,7 +250,6 @@ class _ItemUsageRatesPageState extends State<ItemUsageRatesPage> {
           child: Material(
             color: Colors.transparent,
             child: GestureDetector(
-              // Prevent taps inside the overlay from hitting the barrier
               onTap: () {},
               child: _buildOverlayContent(),
             ),
@@ -150,6 +260,9 @@ class _ItemUsageRatesPageState extends State<ItemUsageRatesPage> {
   }
 
   Widget _buildOverlayContent() {
+    final cubit = context.read<ItemUsageRatesCubit>();
+    final state = cubit.state;
+
     switch (_overlayState) {
       case 'main':
         return _MainFilterOverlay(
@@ -159,26 +272,18 @@ class _ItemUsageRatesPageState extends State<ItemUsageRatesPage> {
       case 'dateRange':
         return _DateRangeOverlay(
           dateRanges: _kDateRanges,
-          selected: _selectedDateRange,
+          selected: state.selectedDateRange,
           onSelect: (range) {
-            setState(() => _selectedDateRange = range);
+            cubit.setDateRange(range);
             _closeOverlay();
           },
         );
       case 'categories':
         return _CategoriesOverlay(
           allCategories: _kAllCategories.map((c) => c.name).toList(),
-          selected: _selectedCategories,
+          selected: state.selectedCategories,
           onToggle: (name) {
-            setState(() {
-              if (_selectedCategories.contains(name)) {
-                if (_selectedCategories.length > 1) {
-                  _selectedCategories.remove(name);
-                }
-              } else {
-                _selectedCategories.add(name);
-              }
-            });
+            cubit.toggleCategory(name);
             _overlayEntry?.markNeedsBuild();
           },
         );
@@ -203,16 +308,16 @@ class _ItemUsageRatesPageState extends State<ItemUsageRatesPage> {
 
   // ── PDF export ─────────────────────────────────────────────────
 
-  Future<void> _exportPdf() async {
+  Future<void> _exportPdf(ItemUsageRatesState state) async {
     final pdfService = PdfExportService();
-    final categories = _filteredCategories
+    final categories = state.categories
         .map((c) => {'name': c.name, 'itemsUsed': c.itemsUsed, 'usageRate': c.usageRatePercent})
         .toList();
     
     final chartImage = await _captureChart();
 
     await pdfService.exportItemUsageRatesReport(
-      dateRange: _selectedDateRange,
+      dateRange: state.selectedDateRange,
       categories: categories,
       chartImage: chartImage,
     );
@@ -223,12 +328,6 @@ class _ItemUsageRatesPageState extends State<ItemUsageRatesPage> {
       );
     }
   }
-
-  // ── Helpers ────────────────────────────────────────────────────
-
-  List<_UsageCategory> get _filteredCategories => _kAllCategories
-      .where((c) => _selectedCategories.contains(c.name))
-      .toList();
 
   // ======================== Build ========================
 
@@ -253,98 +352,146 @@ class _ItemUsageRatesPageState extends State<ItemUsageRatesPage> {
         ),
         centerTitle: true,
       ),
-      body: Column(
-        children: [
-          Expanded(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      body: BlocBuilder<ItemUsageRatesCubit, ItemUsageRatesState>(
+        builder: (context, state) {
+          // Loading state
+          if (state.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          // Error state
+          if (state.errorMessage != null) {
+            return Center(
               child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  // Date range + Filters button row
-                  Row(
+                  Text(
+                    state.errorMessage!,
+                    style: const TextStyle(color: Colors.red, fontSize: 16),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => context.read<ItemUsageRatesCubit>().retryLoad(),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppTheme.primaryColor,
+                    ),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          // Empty state (no categories after filtering)
+          if (state.categories.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(32),
+                child: Text(
+                  'No categories match your selection.',
+                  style: TextStyle(fontSize: 16, color: AppTheme.mutedText),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+
+          // Normal loaded state
+          return Column(
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      // Date range display
-                      Column(
+                      // Date range + Filters button row
+                      Row(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(
-                            _selectedDateRange,
-                            style: const TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.w600,
-                              color: AppTheme.primaryText,
-                            ),
+                          // Date range display
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                state.selectedDateRange,
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                  color: AppTheme.primaryText,
+                                ),
+                              ),
+                              const Text(
+                                '2026',
+                                style: TextStyle(fontSize: 14, color: AppTheme.primaryText),
+                              ),
+                            ],
                           ),
-                          const Text(
-                            '2026',
-                            style: TextStyle(fontSize: 14, color: AppTheme.primaryText),
+                          const Spacer(),
+                          // Filters button — anchored with CompositedTransformTarget
+                          CompositedTransformTarget(
+                            link: _layerLink,
+                            child: GestureDetector(
+                              onTap: () {
+                                if (_overlayState != null) {
+                                  _closeOverlay();
+                                } else {
+                                  _showOverlay('main');
+                                }
+                              },
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 14, vertical: 8),
+                                decoration: BoxDecoration(
+                                  color: AppTheme.primaryColor,
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const Text(
+                                      'Filters',
+                                      style: TextStyle(
+                                          color: Colors.white, fontSize: 14),
+                                    ),
+                                    const SizedBox(width: 4),
+                                    Icon(
+                                      _overlayState != null
+                                          ? Icons.arrow_drop_up
+                                          : Icons.arrow_drop_down,
+                                      color: Colors.white,
+                                      size: 20,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
                           ),
                         ],
                       ),
-                      const Spacer(),
-                      // Filters button — anchored with CompositedTransformTarget
-                      CompositedTransformTarget(
-                        link: _layerLink,
-                        child: GestureDetector(
-                          onTap: () {
-                            if (_overlayState != null) {
-                              _closeOverlay();
-                            } else {
-                              _showOverlay('main');
-                            }
-                          },
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 14, vertical: 8),
-                            decoration: BoxDecoration(
-                              color: AppTheme.primaryColor,
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                const Text(
-                                  'Filters',
-                                  style: TextStyle(
-                                      color: Colors.white, fontSize: 14),
-                                ),
-                                const SizedBox(width: 4),
-                                Icon(
-                                  _overlayState != null
-                                      ? Icons.arrow_drop_up
-                                      : Icons.arrow_drop_down,
-                                  color: Colors.white,
-                                  size: 20,
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
+                      const SizedBox(height: 16),
+                      // Line chart wrapped with RepaintBoundary for capturing
+                      RepaintBoundary(
+                        key: _chartKey,
+                        child: DynamicLineChart(points: state.chartPoints, days: state.chartDays),
                       ),
+                      const SizedBox(height: 20),
+                      // Table
+                      _UsageTable(categories: state.categories),
+                      const SizedBox(height: 12),
                     ],
                   ),
-                  const SizedBox(height: 16),
-                  // Line chart wrapped with RepaintBoundary for capturing
-                  RepaintBoundary(
-                    key: _chartKey,
-                    child: DynamicLineChart(points: _kChartPoints, days: _kChartDays),
-                  ),
-                  const SizedBox(height: 20),
-                  // Table
-                  _UsageTable(categories: _filteredCategories),
-                  const SizedBox(height: 12),
-                ],
+                ),
               ),
-            ),
-          ),
-          // Fixed bottom bar
-          _BottomBar(
-            controller: _searchController,
-            onExport: _exportPdf,
-          ),
-        ],
+              // Fixed bottom bar
+              _BottomBar(
+                controller: _searchController,
+                onExport: () => _exportPdf(state),
+              ),
+            ],
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #552

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Added loading state (`CircularProgressIndicator`) to Inventory Stock Report, Expenditure Report, and Item Usage Rates pages.
- Added error handling with user‑friendly messages and a **Retry** button for all three pages.
- Added empty state messages when no data is available after loading.
- Refactored each page to use a Cubit/State pattern with `isLoading` and `errorMessage` fields.
- Simulated network delay (800ms) and error injection via a `_simulateError` flag (to be replaced later with real Supabase calls).
- Preserved all existing functionality: favorites, PDF export, validation, and filter updates.

### Why was this change necessary?
- Previously, the UI had no feedback while data was being fetched (mock data was static, no async loading).  
- Users would see a blank screen or outdated data without knowing if something was happening or if an error occurred.
- This change improves user experience by clearly indicating loading, handling failures gracefully, and offering a way to retry.

---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (comments preserved)
- [x] Branch is up to date with base branch

---

## 🧪 Testing (if applicable)
<!-- Describe how you tested these changes -->
### Test Steps:
1. Opened the Inventory Stock Report page → observed spinner for ~800ms, then data appeared.
2. Changed date range or search → spinner appeared again, new data loaded.
3. Set `_simulateError = true` in the cubit → error message displayed with Retry button.
4. Clicked Retry → data loaded successfully.
5. (Expenditures) Repeated steps 1‑4.
6. (Item Usage Rates) Repeated steps 1‑4, also toggled categories and date range overlays.
7. Verified empty state: returned empty list from `_fetchXxxData()` → “No data found” message.

### Test Results:
- All three pages now show loading spinners, error messages with Retry, and empty states correctly.
- Existing functionality (favorites, PDF export, validation, filter overlays) remains fully intact.

---

## 👀 Reviewers
<!-- Tag team members for review -->
@Kay9876 @LuisJCruz 