### PR TITLE
Complete terminology glossary

### DIFF
--- a/docs/2-descriptive/domain-description/entities/entities.adoc
+++ b/docs/2-descriptive/domain-description/entities/entities.adoc
@@ -26,7 +26,7 @@ Key domain entities and artifacts. The entities below follow the terminology est
 
 |Item instance (package)
 |A concrete package or unit of an item type that exists in the household.
-|item type reference, location reference, ownership (personal/shared), quantity/availability, optional purchase date, optional expiration date, optional notes
+|item type reference, location reference, ownership status (personal/shared), quantity/availability, optional purchase date, optional expiration date, optional notes
 
 |Inventory (reality)
 |The set of item instances that physically exist in the household at a given time.
@@ -37,7 +37,7 @@ Key domain entities and artifacts. The entities below follow the terminology est
 |artifact type (note/chat/list/memory), item reference (explicit or implicit), last-updated (if recorded)
 
 |Restock list / planner
-|A list of items judged to need replenishment soon.
+|A list of item types judged to need replenishment soon.
 |entries (item types), reason (low/out/expired), optional responsibility marker, status (active/deferred)
 
 |Alert / notification record
@@ -71,11 +71,5 @@ Key domain entities and artifacts. The entities below follow the terminology est
 
 [NOTE]
 ====
-Earlier drafts used terms such as *Home*, *Room*, *Product*, *Stock*, *Owner*, and *Member*. In this document, those terms are replaced by the unified vocabulary defined in the terminology section:
-
-* Home -> Household
-* Room -> Location
-* Product -> Item type
-* Stock -> Item instance (package)
-* Owner / Member -> Household member, with more specific role language used only where needed
+This section uses the canonical vocabulary defined in the terminology glossary. Deprecated vocabulary from earlier drafts has been consolidated into the current terms, such as *Household*, *Location*, *Item type*, *Item instance (package)*, and *Household member*.
 ====

--- a/docs/2-descriptive/domain-description/terminology/terminology.adoc
+++ b/docs/2-descriptive/domain-description/terminology/terminology.adoc
@@ -348,4 +348,64 @@ This section consolidates the domain's ubiquitous language into a single annotat
 | Requirements
 | A persisted representation of an alert, including type, timestamp, and read/unread status, available at minimum for in-app review.
 | Refines the domain-level "alert"; adds persistence and status tracking.
+
+| Barcode scanning
+| Function
+| Requirements
+| A system feature that allows a user to add or identify an item by scanning its barcode instead of entering all item details manually.
+| Related to manual entry and item acquisition.
+
+| Manual entry
+| Function
+| Requirements
+| A system feature that allows a user to add or update item information by typing the details directly into the application.
+| Used when barcode scanning is unavailable, unreliable, or the item has no barcode.
+
+| Shared inventory
+| Concept
+| Requirements
+| An inventory context where multiple household members can view, coordinate, and update item-related information.
+| Related to household membership, permission rules, and duplicate purchase prevention.
+
+| Permission rule
+| Rule
+| Requirements
+| A constraint that defines what actions a user or household member is allowed to perform within a household or shared inventory.
+| Examples include viewing items, editing items, inviting members, removing members, or managing shared household data.
+
+| Grocery list
+| Artifact
+| Requirements
+| A user-facing list of items that need to be purchased or replenished.
+| Related to the restock list / planner, but refers to the system-facing feature used by users.
+
+| Duplicate warning
+| Alert / Rule
+| Requirements
+| A system warning that informs the user when an item, purchase, or restock action may duplicate an existing inventory item or planned item.
+| Supports duplicate purchase prevention and shared household coordination.
+
+| Report
+| Artifact
+| Requirements
+| A system-generated summary that presents inventory, spending, usage, or stock information to help users understand household patterns.
+| May include expenditure reports, stock summaries, budget views, or usage-rate views.
+
+| Usage rate
+| Derived Property
+| Requirements
+| A computed estimate of how quickly an item is consumed over time.
+| Supports reporting, restock planning, and inventory analysis.
+
+| Expenditure report
+| Artifact
+| Requirements
+| A report that summarizes spending entries over a selected period, category, household, or user.
+| Related to budget status, spending category, and spending entry.
+
+| Stock summary
+| Artifact
+| Requirements
+| A report or view that summarizes current item availability, low-stock items, out-of-stock items, and related inventory conditions.
+| Related to availability, quantity, low-stock judgment, and actionable states.
 |===

--- a/docs/2-descriptive/domain-description/terminology/terminology.adoc
+++ b/docs/2-descriptive/domain-description/terminology/terminology.adoc
@@ -47,13 +47,13 @@ This section consolidates the domain's ubiquitous language into a single annotat
 | Entity
 | Domain
 | The kind of an item, independent of a specific package (e.g., "Milk", "Dish soap", "Toilet paper").
-| Previously "Product."
+| Previously "Product." "Asset" and "Belonging" should be avoided unless referring generally to household possessions; use "Item type" for the kind of item and "Item instance" for a specific physical package.
 
 | Item instance (package)
 | Entity
 | Domain
 | A concrete package or unit of an item type that physically exists in the household (e.g., a specific milk carton).
-| Previously "Stock."
+| Previously "Stock." "Asset" and "Belonging" may appear in older drafts, but "Item instance" is the preferred term for a specific physical object/package.
 
 | Inventory (reality)
 | Entity
@@ -83,13 +83,13 @@ This section consolidates the domain's ubiquitous language into a single annotat
 | Artifact
 | Domain
 | A household-oriented list of items that should be replenished soon (fridge note, notes-app list, chat).
-| Delivery method is not part of the domain.
+| Canonical domain term. "Grocery list" is the system-facing feature name when the replenishment list is presented through the application.
 
 | Alert / notification (domain-level)
 | Artifact / Event
 | Domain
 | A message that informs a household member about an actionable condition (low-stock, out-of-stock, expiring, expired, budget threshold crossed).
-| Represents that an actionable condition has been communicated.
+| General notification concept. "Duplicate warning" is a specialized alert used for possible duplicate item or purchase situations.
 
 | Spending entry
 | Record
@@ -209,8 +209,7 @@ This section consolidates the domain's ubiquitous language into a single annotat
 | Event
 | Domain
 | A household member uses an item, decreasing its availability.
-| Consumption rate may increase during exams or when guests visit.
-
+| Usage rate may increase during exams or when guests visit. "Consumption rate" is treated as a synonym of "usage rate."
 | Backup opened
 | Event
 | Domain
@@ -376,26 +375,26 @@ This section consolidates the domain's ubiquitous language into a single annotat
 | Grocery list
 | Artifact
 | Requirements
-| A user-facing list of items that need to be purchased or replenished.
-| Related to the restock list / planner, but refers to the system-facing feature used by users.
+| A system-facing feature that presents items the user may need to purchase or replenish.
+| Use "Restock list / planner" as the canonical domain term. Use "Grocery list" only when referring to the implemented or designed application feature.
 
 | Duplicate warning
 | Alert / Rule
 | Requirements
-| A system warning that informs the user when an item, purchase, or restock action may duplicate an existing inventory item or planned item.
-| Supports duplicate purchase prevention and shared household coordination.
+| A specialized alert that informs the user when an item, purchase, or restock action may duplicate an existing inventory item or planned item.
+| Specialized form of "Alert / notification"; supports duplicate purchase prevention and shared household coordination.
 
 | Report
 | Artifact
 | Requirements
-| A system-generated summary that presents inventory, spending, usage, or stock information to help users understand household patterns.
-| May include expenditure reports, stock summaries, budget views, or usage-rate views.
+| A general system-generated summary that presents household information to support review or decision-making.
+| Umbrella term only. Prefer more specific terms such as "Expenditure report" or "Stock summary" when the report type is known.
 
 | Usage rate
 | Derived Property
 | Requirements
 | A computed estimate of how quickly an item is consumed over time.
-| Supports reporting, restock planning, and inventory analysis.
+| Canonical term. "Consumption rate" is treated as a synonym and should be replaced with "usage rate" in running text when possible.
 
 | Expenditure report
 | Artifact
@@ -408,4 +407,22 @@ This section consolidates the domain's ubiquitous language into a single annotat
 | Requirements
 | A report or view that summarizes current item availability, low-stock items, out-of-stock items, and related inventory conditions.
 | Related to availability, quantity, low-stock judgment, and actionable states.
+
+| Item condition
+| Property
+| Domain
+| The observed state of an item instance, such as new, opened, damaged, expired, spoiled, or usable.
+| Helps household members decide whether an item should be kept, used, repaired, discarded, or replaced.
+
+| Sentimental value
+| Property
+| Domain
+| The personal or emotional importance assigned to an item beyond its practical or financial value.
+| Important for non-consumable household possessions where disposal or replacement decisions are not based only on quantity or cost.
+
+| Inventory operations
+| Concept
+| Domain
+| The set of actions that change or inspect the household inventory, such as adding, locating, updating, transferring, consuming, replenishing, archiving, or discarding items.
+| Umbrella term for inventory-related actions described across scenarios, requirements, and implementation sections.
 |===

--- a/docs/2-descriptive/implementation/automated-stock-check-logic.adoc
+++ b/docs/2-descriptive/implementation/automated-stock-check-logic.adoc
@@ -1,41 +1,41 @@
-= Automated Inventory Stock Check
+= Automated Inventory Availability Check
 
 == Overview
 
-The automated inventory stock check analyzes all stock items within an
-inventory and identifies which items are low on stock or out of stock.
+The automated inventory availability check analyzes the item instances in a tracked inventory record and identifies which items are in a low-stock or out-of-stock condition.
 
-This logic is implemented through the `automatedCheckStock()` use case
-inside the alerts_restock feature.
+This logic is implemented through the `automatedCheckStock()` use case inside the alerts_restock feature. The use case name is kept because it matches the current implementation, but this document uses the domain terminology defined in the glossary.
 
 == Inventory Processing
 
 The use case operates on an `InventoryEntity`.
 
-An inventory contains a map of products and their associated stock items:
+An inventory contains item types and their associated item instances. In the current implementation, these concepts may still appear through legacy class names:
 
 ----
 Map<ProductEntity, List<StockEntity>>
 ----
 
-The function iterates through each product entry and its list of stock
-items. For each `StockEntity`, it calls `checkStock()` using the item's
-current [.underline]#quantity#.
+For documentation purposes:
+
+* `ProductEntity` corresponds to an *Item type*.
+* `StockEntity` corresponds to an *Item instance (package)*.
+
+The function iterates through each item type entry and its list of item instances. For each item instance, it calls `checkStock()` using the item's current [.underline]#quantity#.
 
 == Result Object
 
 The function returns a `StockCheckResult` object containing two lists:
 
-* `lowStockItems` – stock items identified as low stock
-* `outOfStockItems` – stock items identified as out of stock
+* `lowStockItems` – item instances identified as low-stock
+* `outOfStockItems` – item instances identified as out-of-stock
 
-[.underline]#Items that are sufficiently stocked are not included in the result#.
-
+[.underline]#Items with sufficient availability are not included in the result#.
 
 == Testing
 
 Unit tests were implemented to verify the following scenarios:
 
-* low stock items are correctly identified
-* out of stock items are correctly identified
-* sufficiently stocked items are ignored
+* low-stock item instances are correctly identified
+* out-of-stock item instances are correctly identified
+* item instances with sufficient availability are ignored

--- a/docs/lecture-topic-tasks/tangibility_of_domain.adoc
+++ b/docs/lecture-topic-tasks/tangibility_of_domain.adoc
@@ -4,34 +4,66 @@
 **AI Disclosure:** Portions of this lecture topic task were drafted and refined with the assistance of AI tools. All content, metrics, and conclusions have been thoroughly reviewed, edited, and verified by the human author to ensure complete accuracy and project alignment.
 
 == Objective
+
 This document classifies the core phenomena of the Home Inventory domain based on their tangibility: *physically tangible*, *humanly tangible*, or *intangible*. Categorizing these phenomena establishes the fundamental boundaries of data precision, measurement mechanisms, and error validation patterns required by the system.
+
+This document follows the terminology defined in the main terminology glossary. In particular, it uses *Item type* for the kind of item, *Item instance* for a specific physical object or package, *Location* for a storage place, and *Household member* for a person who participates in the household context.
 
 == Tangibility Evaluation Matrix
 
 [cols="2,2,4", options="header"]
 |===
 | Phenomenon / Concept | Classification | Justification & Modeling Strategy
-| Inventory Item (e.g., groceries, tools, electronics) | Physically Tangible | Exists as a physical object within the real world. It possesses measurable dimensions (height, width, mass), can be scanned via a physical barcode/QR label, and occupies a distinct, observable coordinate or container in physical space.
-| Storage Room / Location (e.g., Kitchen Pantry, Garage Shelf) | Physically Tangible | Represents a concrete spatial asset or bounded physical environment. Its capacity boundaries are physically measurable (e.g., cubic feet or shelf surface area), and its contents can be visually verified by household members.
-| Supporting Document (e.g., Physical Receipt, Paper Warranty) | Physically Tangible | Exists in its original state as a physical slip of paper or cardboard card. It possesses material weight and ink markings, and must be digitized via optical sensors (camera/scanner) to be ingested by the system.
-| Item Condition (e.g., Excellent, Good, Fair, Damaged) | Humanly Tangible | Perceived directly by human senses but lacks an exact, automated instrument for objective measurement. An item marked as "Good" by one roommate might be classified as "Fair" by another. It is a subjective assessment modeled using restrictive, standardized enumerations.
-| Sentimental Value (e.g., Low, High, Irreplaceable) | Humanly Tangible | An internal emotional weight or subjective preference attributed to an asset by an individual household member. It cannot be derived using mathematical formulas or hardware sensors. Modeled strictly as a user-defined qualitative metric.
-| Roommate Trust & Compliance (e.g., Probability of logging item usage) | Humanly Tangible | A psychological and social phenomenon reflecting how consistently household members accurately report inventory consumption. While critical to preventing stale data, it is a fluid, human variable that cannot be perfectly codified.
-| Item Category (e.g., Perishables, Cleaning Supplies) | Intangible | A purely logical classification, taxonomy, or abstract mathematical set. Categories do not exist as standalone physical objects; they are sorting tags used to simplify indexing and database indexing lookup queries.
-| Inventory Operations (e.g., Add Item, Decrement Stock, Delete) | Intangible | Abstract state mutations and logical operational events. An operation has no physical presence; it exists only as an instantaneous transaction entry or an entry in a database ledger/audit trail tracking code actions.
-| User Permission Level (e.g., Owner, Member, Viewer Roles) | Intangible | An abstract security compliance framework concept modeled as an enumerated access control specification sort. It dictates what system operations a token can perform, existing purely as logical rules within the software architecture.
+
+| Item instance (package) (e.g., groceries, tools, electronics)
+| Physically Tangible
+| Exists as a physical object within the real world. It can have measurable physical properties, can be scanned through a physical barcode or QR label when available, and occupies a distinct observable location within the household.
+
+| Location (e.g., kitchen pantry, garage shelf)
+| Physically Tangible
+| Represents a concrete storage place or bounded physical environment within the household. Its capacity boundaries may be physically estimated or measured, and its contents can be visually verified by household members.
+
+| Supporting document (e.g., physical receipt, paper warranty)
+| Physically Tangible
+| Exists in its original state as a physical slip of paper or card. It possesses material weight and visible markings, and must be digitized through a camera or scanner before being represented by the system.
+
+| Item condition (e.g., excellent, good, fair, damaged)
+| Humanly Tangible
+| Perceived directly by human senses but difficult to measure automatically with full objectivity. An item instance marked as "good" by one household member might be classified as "fair" by another. The system should model this as a controlled qualitative value rather than unrestricted text.
+
+| Sentimental value (e.g., low, high, irreplaceable)
+| Humanly Tangible
+| Represents the personal or emotional importance assigned to an item instance beyond its practical or financial value. It cannot be derived only from quantity, cost, or physical measurements, so it must be captured as a user-provided qualitative value when needed.
+
+| Household member trust and update behavior
+| Humanly Tangible
+| Reflects how consistently household members report inventory changes, consumption, or replenishment. While important for preventing stale data, this is a social behavior that cannot be perfectly measured by the system.
+
+| Item category (e.g., perishables, cleaning supplies)
+| Intangible
+| A logical classification used to organize item types. Categories do not exist as standalone physical objects; they are sorting labels that support filtering, reporting, and data organization.
+
+| Inventory operations (e.g., add item, update quantity, discard item)
+| Intangible
+| Abstract actions or state changes performed on tracked inventory records and item instances. An operation has no physical presence; it is represented through application behavior, transaction history, or database records.
+
+| Permission rule (e.g., admin, editor, viewer)
+| Intangible
+| A logical access-control constraint that defines what actions a household member can perform. It exists as a rule within the software architecture rather than as a physical or directly observable object.
 |===
 
 == Boundary Cases & Engineering Rationale
 
-The separation boundary between Physically Tangible domain entities and Humanly Tangible attributes represents a critical transition vector in software design:
+The separation boundary between physically tangible domain entities and humanly tangible attributes is important for software design because not every meaningful household property can be measured automatically.
 
 1. The Item Condition Paradox:
-An item's physical state undergoes concrete, systematic degradation in the physical world (e.g., food spoiling or a tool rusting). However, the system cannot measure this automatically without expensive chemical or visual diagnostic arrays. The representation of this state relies completely on human sensory perception and subjective manual entry. 
 
-Design Resolution: To manage this ambiguity, the software architecture enforces rigid data contracts (`Sorts`) in the database layer via structured constraints (enums) rather than allowing open-ended text fields. This maps humanly tangible perceptions into bounded, predictable system values.
+An item instance can physically degrade in the real world, such as food spoiling or a tool rusting. However, the system cannot measure this automatically without specialized sensors or expensive diagnostic tools. The representation of this state therefore relies on human sensory perception and manual entry.
+
+Design Resolution: To manage this ambiguity, the software architecture should represent item condition using controlled values, such as enums or predefined options, instead of unrestricted text fields. This maps humanly tangible perceptions into bounded and predictable system values.
 
 2. The Digitized Physical Document:
-A receipt or warranty card is physically tangible. Once scanned, its image and extracted OCR text fields are processed by the system. 
 
-Design Resolution: The system models the *original source document* as physically tangible (prone to being lost, ripped, or faded), while treating the metadata record as an intangible collection of strings and numbers. Validation rules must account for errors introduced during this physical-to-digital translation boundary (e.g., blurry photos, unreadable text).
+A receipt or warranty card is physically tangible. Once scanned, its image and extracted text fields are processed by the system.
+
+Design Resolution: The system models the original source document as physically tangible because it can be lost, damaged, or unreadable. Its digitized metadata record is intangible because it exists as stored strings, numbers, or file references. Validation rules must account for errors introduced during the physical-to-digital transition, such as blurry photos or unreadable text.


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
Closes #594: [Documentation]: Complete Terminology Glossary (Section 2.1.2 - Terminology)

---

## 📝 Description

### What changed?
- Updated the terminology glossary in `docs/2-descriptive/domain-description/terminology/terminology.adoc`.
- Added missing requirements-facing and system-facing terms used across the documentation.
- Added definitions and notes for barcode scanning, manual entry, shared inventory, permission rules, grocery list, duplicate warnings, reports, usage rate, expenditure reports, and stock summaries.

### Why was this change necessary?
This change was necessary to complete the terminology glossary for Milestone 3 and improve consistency across the project documentation. Several terms were used in requirements, implementation notes, diagrams, and feature documentation but were not clearly defined in the main terminology section. Adding these entries helps ensure that important Home Inventory terms have a clear, shared meaning throughout the document.

---

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] Branch is up to date with base branch

---

## 🧪 Testing (if applicable)

### Test Steps:
1. Reviewed the updated `terminology.adoc` file.
2. Confirmed the new entries follow the existing AsciiDoc table format.
3. Checked that each new term includes a type, phase, definition, and notes.

### Test Results:
The terminology glossary was updated successfully. The added entries follow the existing documentation structure and support clearer terminology usage across Milestone 3 documentation.

---

## 📸 Screenshots/Videos (if applicable)
N/A

---

## 👀 Reviewers
@aryamdiaz 