### PR TITLE
Fix PDF export and share with real inventory data

### DIFF
--- a/src/lib/core/data/services/pdf_export_service.dart
+++ b/src/lib/core/data/services/pdf_export_service.dart
@@ -75,9 +75,16 @@ class PdfExportService {
             headerStyle: pw.TextStyle(fontWeight: pw.FontWeight.bold),
             headerDecoration: const pw.BoxDecoration(),
             cellAlignment: pw.Alignment.centerLeft,
+            columnWidths: const {
+              0: pw.FlexColumnWidth(3),
+              1: pw.FlexColumnWidth(1),
+            },
             headers: const ['Category', 'Quantity'],
             data: categories
-                .map((c) => [c['name'], c['quantity'].toString()])
+                .map((c) => [
+                      (c['name'] ?? '').toString(),
+                      (c['quantity'] ?? 0).toString(),
+                    ])
                 .toList(),
           ),
           pw.SizedBox(height: 20),
@@ -93,16 +100,20 @@ class PdfExportService {
             headerStyle: pw.TextStyle(fontWeight: pw.FontWeight.bold),
             headerDecoration: const pw.BoxDecoration(),
             cellAlignment: pw.Alignment.centerLeft,
-            headers: const ['Item', 'Category', 'Quantity', 'Status'],
+            columnWidths: const {
+              0: pw.FlexColumnWidth(3),
+              1: pw.FlexColumnWidth(2),
+              2: pw.FlexColumnWidth(1),
+              3: pw.FlexColumnWidth(2),
+            },
+            headers: const ['Item', 'Category', 'Qty', 'Status'],
             data: items
-                .map(
-                  (i) => [
-                i['name'],
-                i['category'],
-                i['quantity'].toString(),
-                i['status'],
-              ],
-            )
+                .map((i) => [
+                      (i['name'] ?? '').toString(),
+                      (i['category'] ?? '').toString(),
+                      (i['quantity'] ?? 0).toString(),
+                      (i['status'] ?? '').toString(),
+                    ])
                 .toList(),
           ),
         ],
@@ -132,7 +143,7 @@ class PdfExportService {
     );
   }
 
-  Future<void> exportExpenditureReport({
+  Future<Uint8List> generateExpenditureReportPdfBytes({
     required DateTime startDate,
     required DateTime endDate,
     required List<Map<String, dynamic>> categories,
@@ -198,24 +209,47 @@ class PdfExportService {
             headerStyle: pw.TextStyle(fontWeight: pw.FontWeight.bold),
             headerDecoration: const pw.BoxDecoration(),
             cellAlignment: pw.Alignment.centerLeft,
+            columnWidths: const {
+              0: pw.FlexColumnWidth(3),
+              1: pw.FlexColumnWidth(2),
+              2: pw.FlexColumnWidth(2),
+            },
             headers: const ['Category', 'Amount (\$)', '% of Total'],
             data: categories
-                .map((c) => [
-                      c['name'],
-                      (c['amount'] as double).toStringAsFixed(2),
-                      totalAmount > 0
-                          ? '${((c['amount'] as double) / totalAmount * 100).toStringAsFixed(1)}%'
-                          : '0%',
-                    ])
+                .map((c) {
+                  final amount = (c['amount'] as num?)?.toDouble() ?? 0.0;
+                  return [
+                    (c['name'] ?? '').toString(),
+                    amount.toStringAsFixed(2),
+                    totalAmount > 0
+                        ? '${(amount / totalAmount * 100).toStringAsFixed(1)}%'
+                        : '0%',
+                  ];
+                })
                 .toList(),
           ),
         ],
       ),
     );
 
-    await Printing.layoutPdf(
-      onLayout: (format) async => pdf.save(),
+    return pdf.save();
+  }
+
+  Future<void> exportExpenditureReport({
+    required DateTime startDate,
+    required DateTime endDate,
+    required List<Map<String, dynamic>> categories,
+    required double totalAmount,
+    Uint8List? chartImage,
+  }) async {
+    final pdfBytes = await generateExpenditureReportPdfBytes(
+      startDate: startDate,
+      endDate: endDate,
+      categories: categories,
+      totalAmount: totalAmount,
+      chartImage: chartImage,
     );
+    await Printing.layoutPdf(onLayout: (format) async => pdfBytes);
   }
 
   // ======================== Item Usage Rates Report ========================
@@ -284,12 +318,17 @@ class PdfExportService {
             headerStyle: pw.TextStyle(fontWeight: pw.FontWeight.bold),
             headerDecoration: const pw.BoxDecoration(),
             cellAlignment: pw.Alignment.centerLeft,
+            columnWidths: const {
+              0: pw.FlexColumnWidth(3),
+              1: pw.FlexColumnWidth(2),
+              2: pw.FlexColumnWidth(2),
+            },
             headers: const ['Category', 'Items Used', 'Usage Rate (%)'],
             data: categories
                 .map((c) => [
-                      c['name'],
-                      c['itemsUsed'].toString(),
-                      '${c['usageRate']}%',
+                      (c['name'] ?? '').toString(),
+                      (c['itemsUsed'] ?? 0).toString(),
+                      '${c['usageRate'] ?? 0}%',
                     ])
                 .toList(),
           ),

--- a/src/lib/core/data/services/pdf_share_helper.dart
+++ b/src/lib/core/data/services/pdf_share_helper.dart
@@ -54,6 +54,88 @@ class PdfShareHelper {
     }
   }
 
+  static Future<void> shareExpenditureReport({
+    required BuildContext context,
+    required DateTime startDate,
+    required DateTime endDate,
+    required List<Map<String, dynamic>> categories,
+    required double totalAmount,
+    Uint8List? chartImage,
+    String fileName = 'expenditure_report.pdf',
+    String reportType = 'expenditure',
+  }) async {
+    try {
+      final pdfExportService = PdfExportService();
+      final pdfShareService = PdfShareService();
+
+      final pdfBytes = await pdfExportService.generateExpenditureReportPdfBytes(
+        startDate: startDate,
+        endDate: endDate,
+        categories: categories,
+        totalAmount: totalAmount,
+        chartImage: chartImage,
+      );
+
+      final result = await pdfShareService.uploadPdfAndCreateSignedUrl(
+        pdfBytes: pdfBytes,
+        fileName: fileName,
+        reportType: reportType,
+        expiresInSeconds: 3600,
+      );
+
+      if (!context.mounted) return;
+
+      await _showShareDialog(context, result.signedUrl);
+    } catch (e) {
+      debugPrint('PDF SHARE ERROR: $e');
+
+      if (!context.mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Share failed: $e')),
+      );
+    }
+  }
+
+  static Future<void> shareItemUsageRatesReport({
+    required BuildContext context,
+    required String dateRange,
+    required List<Map<String, dynamic>> categories,
+    Uint8List? chartImage,
+    String fileName = 'item_usage_rates_report.pdf',
+    String reportType = 'item_usage_rates',
+  }) async {
+    try {
+      final pdfExportService = PdfExportService();
+      final pdfShareService = PdfShareService();
+
+      final pdfBytes = await pdfExportService.generateItemUsageRatesReportPdfBytes(
+        dateRange: dateRange,
+        categories: categories,
+        chartImage: chartImage,
+      );
+
+      final result = await pdfShareService.uploadPdfAndCreateSignedUrl(
+        pdfBytes: pdfBytes,
+        fileName: fileName,
+        reportType: reportType,
+        expiresInSeconds: 3600,
+      );
+
+      if (!context.mounted) return;
+
+      await _showShareDialog(context, result.signedUrl);
+    } catch (e) {
+      debugPrint('PDF SHARE ERROR: $e');
+
+      if (!context.mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Share failed: $e')),
+      );
+    }
+  }
+
   static Future<void> _showShareDialog(
       BuildContext context,
       String signedUrl,

--- a/src/lib/core/data/services/pdf_share_service.dart
+++ b/src/lib/core/data/services/pdf_share_service.dart
@@ -24,7 +24,8 @@ class PdfShareService {
     int expiresInSeconds = 3600,
   }) async {
     final user = _supabase.auth.currentUser;
-    final ownerFolder = user?.id ?? 'test-user';
+    if (user == null) throw Exception('No authenticated user');
+    final ownerFolder = user.id;
 
     final sanitizedReportType = reportType
         .trim()

--- a/src/lib/features/reports/presentation/pages/expenditure_report_page.dart
+++ b/src/lib/features/reports/presentation/pages/expenditure_report_page.dart
@@ -10,6 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/data/services/pdf_export_service.dart';
+import '../../../../core/data/services/pdf_share_helper.dart';
 import '../../../../config/theme.dart';
 import '../../domain/entities/report_filters.dart';
 import '../../domain/repositories/favorites_repository.dart';
@@ -253,6 +254,21 @@ class _ExpenditureViewState extends State<_ExpenditureView> {
     );
   }
 
+  Future<void> _sharePdf(BuildContext context, ExpenditureState state) async {
+    final categories = state.categories
+        .map((c) => {'name': c.name, 'amount': c.amount})
+        .toList();
+    final chartImage = await _captureChart();
+    await PdfShareHelper.shareExpenditureReport(
+      context: context,
+      startDate: state.startDate,
+      endDate: state.endDate,
+      categories: categories,
+      totalAmount: state.totalAmount,
+      chartImage: chartImage,
+    );
+  }
+
   void _showSaveFavoriteDialog(BuildContext context) {
     showDialog(
       context: context,
@@ -379,6 +395,17 @@ class _ExpenditureViewState extends State<_ExpenditureView> {
             onPressed: () => _showSaveFavoriteDialog(context),
             icon: const Icon(Icons.save_alt, color: AppTheme.primaryText),
             tooltip: 'Save current filters',
+          ),
+          const SizedBox(width: 4),
+          // Share PDF button
+          BlocBuilder<ExpenditureCubit, ExpenditureState>(
+            builder: (context, state) {
+              return IconButton(
+                onPressed: () => _sharePdf(context, state),
+                icon: const Icon(Icons.share, color: AppTheme.primaryText),
+                tooltip: 'Share PDF',
+              );
+            },
           ),
           const SizedBox(width: 8),
         ],


### PR DESCRIPTION
- Add null safety to all table data fields in PdfExportService to prevent crashes when Supabase returns null values
- Add explicit column widths to all tables to prevent overflow with long names
- Extract generateExpenditureReportPdfBytes so expenditure PDFs can be shared; exportExpenditureReport now delegates to it instead of duplicating logic
- Add shareExpenditureReport and shareItemUsageRatesReport to PdfShareHelper
- Remove 'test-user' fallback in PdfShareService; throw instead when unauthenticated
- Add Share button to ExpenditureReportPage AppBar

# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #666 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
  1. pdf_export_service.dart — added null safety (?? '') on all table data
  fields, added column widths to all tables to prevent overflow, extracted
  generateExpenditureReportPdfBytes so the expenditure report can be shared.
  2. pdf_share_helper.dart — added shareExpenditureReport and
  shareItemUsageRatesReport methods (only inventory had share before).
  3. pdf_share_service.dart — removed 'test-user' fallback, now throws if
  not logged in.
  4. expenditure_report_page.dart — added a share button to the AppBar and
  the _sharePdf method to call it.

### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
to use real user data

---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [x ] Code follows project style guidelines
- [x] Self-review completed
- [x ] Documentation updated
- [x ] Branch is up to date with base branch

---

## 🧪 Testing (if applicable)
<!-- Describe how you tested these changes -->
### Test Steps:
1. 
2. 
3. 

### Test Results:
<!-- What was the outcome? -->


---

## 📸 Screenshots/Videos (if applicable)
<!-- Add screenshots or videos demonstrating the changes -->


---

## 👀 Reviewers
<!-- Tag team members for review -->
@Kay9876 @FabianVelezOcasio 
