### PR TITLE
Make Grocery List Items Display on Page

### DIFF
--- a/src/lib/config/injection_dependencies.dart
+++ b/src/lib/config/injection_dependencies.dart
@@ -21,6 +21,7 @@ import 'package:src/features/example_feature/domain/usecases/stream_todos.dart';
 import 'package:src/features/example_feature/domain/usecases/unmark_todo_completed.dart';
 import 'package:src/features/example_feature/domain/usecases/update_todo.dart';
 import 'package:src/features/example_feature/presentation/cubits/todo_cubit.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_cubit.dart';
 import 'package:src/features/reports/domain/repositories/supabase_report_repository.dart';
 import 'package:src/features/reports/domain/repositories/report_repositories.dart';
 import 'package:src/features/reports/presentation/cubit/report_list_cubit.dart';
@@ -105,6 +106,8 @@ Future<void> initializeDependencies() async {
   sl.registerSingleton<TodoCubit>(
     TodoCubit(sl(), sl(), sl(), sl(), sl(), sl()),
   );
+
+  sl.registerSingleton<GroceryListCubit>(GroceryListCubit());
 
   /// The dependencies of the features might be a bit interleaved because
   /// they're not 100% standalone.

--- a/src/lib/core/presentation/widgets/button.dart
+++ b/src/lib/core/presentation/widgets/button.dart
@@ -5,18 +5,17 @@ import 'package:sizer/sizer.dart';
 import 'package:src/features/grocery_list/data/constants.dart';
 
 class Button extends StatelessWidget {
-  const Button({super.key, required this.buttonText});
+  const Button({super.key, required this.buttonText, this.onPressed});
 
   final String buttonText;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 4.w, vertical: 5.h),
       child: CupertinoButton(
-        onPressed: () {
-          context.pop();
-        },
+        onPressed: onPressed ?? () => context.pop(),
         color: primary,
         padding: EdgeInsets.symmetric(horizontal: 4.w, vertical: 2.h),
         borderRadius: BorderRadius.circular(15),

--- a/src/lib/core/presentation/widgets/snack_bar.dart
+++ b/src/lib/core/presentation/widgets/snack_bar.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:top_snackbar_flutter/custom_snack_bar.dart';
+import 'package:top_snackbar_flutter/top_snack_bar.dart';
+
+class MySnackBar {
+  void showFailure({required BuildContext context, required String message}) {
+    showTopSnackBar(
+      Overlay.of(context),
+      CustomSnackBar.error(
+        message: message,
+      ),
+    );
+  }
+
+  void showSuccess({required BuildContext context, required String message}) {
+    showTopSnackBar(
+      Overlay.of(context),
+      CustomSnackBar.success(message: message),
+    );
+  }
+}

--- a/src/lib/features/grocery_list/data/constants.dart
+++ b/src/lib/features/grocery_list/data/constants.dart
@@ -3,3 +3,104 @@ import 'dart:ui';
 Color backgroundColor = Color(0xFFFBF7EF);
 Color primary = Color(0xFF3A5A40);
 Color secondary = Color(0xFFA3B18A);
+
+const String customCollectionName = 'Custom';
+
+bool isCustomCollection(String name) => name == customCollectionName;
+
+const List<String> collectionNames = [
+  'Vegetables',
+  'Fruits',
+  'Dairy',
+  'Meat',
+  'Snacks',
+  'Beverages',
+  'Frozen',
+  'Pantry',
+];
+
+const Map<String, List<String>> collectionItems = {
+  'Vegetables': [
+    'Tomatoes',
+    'Carrots',
+    'Lettuce',
+    'Onions',
+    'Potatoes',
+    'Broccoli',
+    'Spinach',
+    'Peppers',
+    'Cucumber',
+    'Celery',
+  ],
+  'Fruits': [
+    'Apples',
+    'Bananas',
+    'Oranges',
+    'Grapes',
+    'Strawberries',
+    'Blueberries',
+    'Mangoes',
+    'Pineapple',
+  ],
+  'Dairy': [
+    'Milk',
+    'Cheese',
+    'Yogurt',
+    'Butter',
+    'Eggs',
+    'Cream',
+    'Sour Cream',
+  ],
+  'Meat': [
+    'Chicken',
+    'Beef',
+    'Pork',
+    'Turkey',
+    'Bacon',
+    'Sausage',
+    'Ground Beef',
+  ],
+  'Snacks': [
+    'Chips',
+    'Crackers',
+    'Popcorn',
+    'Granola Bars',
+    'Nuts',
+    'Pretzels',
+    'Cookies',
+  ],
+  'Beverages': [
+    'Water',
+    'Juice',
+    'Soda',
+    'Coffee',
+    'Tea',
+    'Sports Drinks',
+    'Sparkling Water',
+  ],
+  'Frozen': [
+    'Frozen Pizza',
+    'Ice Cream',
+    'Frozen Vegetables',
+    'Frozen Fruit',
+    'Frozen Meals',
+    'Frozen Fries',
+  ],
+  'Pantry': [
+    'Rice',
+    'Pasta',
+    'Bread',
+    'Flour',
+    'Sugar',
+    'Olive Oil',
+    'Canned Beans',
+    'Cereal',
+  ],
+};
+
+List<String> itemsForCollection(String collectionName) {
+  if (isCustomCollection(collectionName)) {
+    return [];
+  }
+  return collectionItems[collectionName] ?? [];
+}

--- a/src/lib/features/grocery_list/domain/entities/custom_collection_item.dart
+++ b/src/lib/features/grocery_list/domain/entities/custom_collection_item.dart
@@ -1,0 +1,28 @@
+import 'package:equatable/equatable.dart';
+
+class CustomCollectionItem extends Equatable {
+  const CustomCollectionItem({
+    required this.id,
+    required this.name,
+    this.imagePath,
+  });
+
+  final String id;
+  final String name;
+  final String? imagePath;
+
+  CustomCollectionItem copyWith({
+    String? id,
+    String? name,
+    String? imagePath,
+  }) {
+    return CustomCollectionItem(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      imagePath: imagePath ?? this.imagePath,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, name, imagePath];
+}

--- a/src/lib/features/grocery_list/domain/entities/grocery_list_item.dart
+++ b/src/lib/features/grocery_list/domain/entities/grocery_list_item.dart
@@ -1,0 +1,24 @@
+import 'package:equatable/equatable.dart';
+
+class GroceryListItem extends Equatable {
+  const GroceryListItem({
+    required this.id,
+    required this.name,
+    this.quantity = 1,
+  });
+
+  final String id;
+  final String name;
+  final int quantity;
+
+  GroceryListItem copyWith({String? id, String? name, int? quantity}) {
+    return GroceryListItem(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      quantity: quantity ?? this.quantity,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, name, quantity];
+}

--- a/src/lib/features/grocery_list/presentation/cubits/grocery_list_cubit.dart
+++ b/src/lib/features/grocery_list/presentation/cubits/grocery_list_cubit.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:src/features/grocery_list/domain/entities/custom_collection_item.dart';
+import 'package:src/features/grocery_list/domain/entities/grocery_list_item.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_state.dart';
+
+class GroceryListCubit extends Cubit<GroceryListState> {
+  GroceryListCubit() : super(const GroceryListState());
+
+  bool addItem(String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) {
+      return false;
+    }
+
+    final existingIndex = state.items.indexWhere(
+      (item) => item.name.toLowerCase() == trimmed.toLowerCase(),
+    );
+
+    if (existingIndex >= 0) {
+      final updatedItems = [...state.items];
+      final existing = updatedItems[existingIndex];
+      updatedItems[existingIndex] = existing.copyWith(
+        quantity: existing.quantity + 1,
+      );
+      emit(state.copyWith(items: updatedItems));
+      return true;
+    }
+
+    final item = GroceryListItem(
+      id: DateTime.now().microsecondsSinceEpoch.toString(),
+      name: trimmed,
+    );
+    emit(state.copyWith(items: [...state.items, item]));
+    return true;
+  }
+
+  bool addCustomCollectionItem(String name, {String? imagePath}) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) {
+      return false;
+    }
+
+    final isDuplicate = state.customCollectionItems.any(
+      (item) => item.name.toLowerCase() == trimmed.toLowerCase(),
+    );
+    if (isDuplicate) {
+      return false;
+    }
+
+    final item = CustomCollectionItem(
+      id: DateTime.now().microsecondsSinceEpoch.toString(),
+      name: trimmed,
+      imagePath: imagePath,
+    );
+    emit(
+      state.copyWith(
+        customCollectionItems: [...state.customCollectionItems, item],
+      ),
+    );
+    return true;
+  }
+
+  void removeCustomCollectionItem(String id) {
+    final updated = state.customCollectionItems
+        .where((item) => item.id != id)
+        .toList();
+    emit(state.copyWith(customCollectionItems: updated));
+  }
+
+  void incrementQuantity(String id) {
+    _updateQuantity(id, 1);
+  }
+
+  void decrementQuantity(String id) {
+    final item = state.items.firstWhere((entry) => entry.id == id);
+    if (item.quantity <= 1) {
+      removeItem(id);
+      return;
+    }
+    _updateQuantity(id, -1);
+  }
+
+  void removeItem(String id) {
+    emit(
+      state.copyWith(
+        items: state.items.where((item) => item.id != id).toList(),
+      ),
+    );
+  }
+
+  void _updateQuantity(String id, int delta) {
+    final updatedItems = state.items.map((item) {
+      if (item.id != id) {
+        return item;
+      }
+      return item.copyWith(quantity: item.quantity + delta);
+    }).toList();
+    emit(state.copyWith(items: updatedItems));
+  }
+}

--- a/src/lib/features/grocery_list/presentation/cubits/grocery_list_state.dart
+++ b/src/lib/features/grocery_list/presentation/cubits/grocery_list_state.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+import 'package:src/features/grocery_list/domain/entities/custom_collection_item.dart';
+import 'package:src/features/grocery_list/domain/entities/grocery_list_item.dart';
+
+class GroceryListState extends Equatable {
+  const GroceryListState({
+    this.items = const [],
+    this.customCollectionItems = const [],
+  });
+
+  final List<GroceryListItem> items;
+  final List<CustomCollectionItem> customCollectionItems;
+
+  bool get hasCustomCollection => customCollectionItems.isNotEmpty;
+
+  GroceryListState copyWith({
+    List<GroceryListItem>? items,
+    List<CustomCollectionItem>? customCollectionItems,
+  }) {
+    return GroceryListState(
+      items: items ?? this.items,
+      customCollectionItems:
+          customCollectionItems ?? this.customCollectionItems,
+    );
+  }
+
+  @override
+  List<Object?> get props => [items, customCollectionItems];
+}

--- a/src/lib/features/grocery_list/presentation/pages/add_item.dart
+++ b/src/lib/features/grocery_list/presentation/pages/add_item.dart
@@ -4,11 +4,15 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sizer/sizer.dart';
+import 'package:src/config/injection_dependencies.dart';
 import 'package:src/core/presentation/widgets/button.dart';
+import 'package:src/core/presentation/widgets/snack_bar.dart';
 import 'package:src/features/grocery_list/data/constants.dart';
 import 'package:src/core/presentation/widgets/text_field.dart';
 import 'package:src/core/presentation/widgets/top.dart';
 import 'package:src/core/presentation/widgets/upload_image.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_cubit.dart';
+import 'package:src/features/grocery_list/presentation/widgets/category_grid_tile.dart';
 
 class AddItem extends StatefulWidget {
   const AddItem({super.key, this.isCustom = false});
@@ -23,7 +27,41 @@ class _AddItemState extends State<AddItem> {
   File? itemImage;
 
   @override
+  void dispose() {
+    name.dispose();
+    super.dispose();
+  }
+
+  void _onSubmit(BuildContext context) {
+    if (widget.isCustom) {
+      context.pop();
+      return;
+    }
+
+    final added = sl<GroceryListCubit>().addCustomCollectionItem(
+      name.text,
+      imagePath: itemImage?.path,
+    );
+
+    if (!added) {
+      MySnackBar().showFailure(
+        context: context,
+        message: 'Enter a unique item name to add to Custom.',
+      );
+      return;
+    }
+
+    MySnackBar().showSuccess(
+      context: context,
+      message: 'Saved to $customCollectionName collection.',
+    );
+    context.pop();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final previewName = name.text.trim().isEmpty ? 'Item' : name.text.trim();
+
     return Scaffold(
       backgroundColor: backgroundColor,
       body: ListView(
@@ -36,7 +74,7 @@ class _AddItemState extends State<AddItem> {
             iconColor: primary,
           ),
           SizedBox(height: 2.h),
-          itemTile(),
+          itemPreview(previewName),
           SizedBox(height: 2.h),
           BuildTextField(
             label: 'Name',
@@ -46,6 +84,7 @@ class _AddItemState extends State<AddItem> {
             required: true,
             padding: false,
             isDarkMode: true,
+            onChange: (_) => setState(() {}),
           ),
           SizedBox(height: 2.h),
           UploadImage(
@@ -60,40 +99,48 @@ class _AddItemState extends State<AddItem> {
       ),
       bottomNavigationBar: Button(
         buttonText: widget.isCustom ? "Edit Item" : "Add Item",
+        onPressed: () => _onSubmit(context),
       ),
     );
   }
 
-  Widget itemTile() {
+  Widget itemPreview(String title) {
+    if (itemImage != null) {
+      return Align(
+        alignment: Alignment.center,
+        child: Column(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(15),
+              child: Image.file(
+                itemImage!,
+                width: 45.w,
+                height: 20.h,
+                fit: BoxFit.cover,
+              ),
+            ),
+            SizedBox(height: 1.h),
+            Text(
+              title,
+              style: TextStyle(
+                fontSize: 18.sp,
+                fontWeight: FontWeight.bold,
+                color: primary,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      );
+    }
+
     return Align(
       alignment: Alignment.center,
-      child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 2.w, vertical: 2.h),
+      child: IgnorePointer(
         child: SizedBox(
           width: 45.w,
-          height: 20.h,
-          child: Container(
-            decoration: BoxDecoration(
-              color: primary,
-              borderRadius: BorderRadius.circular(15),
-            ),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                SizedBox(height: 1.h),
-                Container(color: Colors.red, width: 20.w, height: 10.h),
-                Text(
-                  "Item",
-                  style: TextStyle(
-                    fontSize: 20.sp,
-                    fontWeight: FontWeight.bold,
-                    color: backgroundColor,
-                  ),
-                ),
-                SizedBox(height: 1.h),
-              ],
-            ),
-          ),
+          child: CategoryGridTile(name: title, onTap: () {}),
         ),
       ),
     );

--- a/src/lib/features/grocery_list/presentation/pages/categories.dart
+++ b/src/lib/features/grocery_list/presentation/pages/categories.dart
@@ -1,35 +1,83 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' hide SearchBar;
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sizer/sizer.dart';
+import 'package:src/config/injection_dependencies.dart';
 import 'package:src/config/router.dart';
 import 'package:src/core/presentation/widgets/search_bar.dart';
+import 'package:src/core/presentation/widgets/snack_bar.dart';
 import 'package:src/features/grocery_list/data/constants.dart';
 import 'package:src/core/presentation/widgets/top.dart';
+import 'package:src/features/grocery_list/domain/entities/custom_collection_item.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_cubit.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_state.dart';
+import 'package:src/features/grocery_list/presentation/widgets/category_grid_tile.dart';
 
 class Categories extends StatelessWidget {
-  const Categories({super.key, this.isCustom = true});
-  final bool isCustom;
+  const Categories({
+    super.key,
+    required this.collectionName,
+  });
+
+  final String collectionName;
+
+  bool get _isCustom => isCustomCollection(collectionName);
+
+  List<String> _builtInItems() => itemsForCollection(collectionName);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: backgroundColor,
-      body: ListView(
-        padding: EdgeInsets.symmetric(horizontal: 4.w),
-        children: [
-          Top(
-            color: Colors.black,
-            leftButton: () => context.pop(),
-            title: "Vegetables",
-            iconColor: primary,
-            widget: isCustom ? customButton(context) : null,
-          ),
-          MySearchBar(),
-          SizedBox(height: 2.h),
-          item(),
-        ],
-      ),
+      body: _isCustom
+          ? BlocBuilder<GroceryListCubit, GroceryListState>(
+              builder: (context, state) => _buildBody(
+                context,
+                customItems: state.customCollectionItems,
+              ),
+            )
+          : _buildBody(context, builtInItems: _builtInItems()),
+    );
+  }
+
+  Widget _buildBody(
+    BuildContext context, {
+    List<String> builtInItems = const [],
+    List<CustomCollectionItem> customItems = const [],
+  }) {
+    final hasItems = _isCustom ? customItems.isNotEmpty : builtInItems.isNotEmpty;
+
+    return ListView(
+      padding: EdgeInsets.symmetric(horizontal: 4.w),
+      children: [
+        Top(
+          color: Colors.black,
+          leftButton: () => context.pop(),
+          title: collectionName,
+          iconColor: primary,
+          widget: _isCustom ? customButton(context) : null,
+        ),
+        MySearchBar(),
+        SizedBox(height: 2.h),
+        if (!hasItems)
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 4.h),
+            child: Center(
+              child: Text(
+                _isCustom
+                    ? 'No custom items yet.\nTap + on the Grocery screen to add one.'
+                    : 'No items in this collection yet.',
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 16.sp, color: Colors.grey[700]),
+              ),
+            ),
+          )
+        else if (_isCustom)
+          _customItemGrid(context, customItems)
+        else
+          _builtInItemGrid(context, builtInItems),
+      ],
     );
   }
 
@@ -49,44 +97,58 @@ class Categories extends StatelessWidget {
     );
   }
 
-  Widget item() {
+  Widget _builtInItemGrid(BuildContext context, List<String> items) {
     return GridView.builder(
       padding: EdgeInsets.zero,
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
-      itemCount: 10,
+      itemCount: items.length,
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 2,
+        mainAxisSpacing: 1.5.h,
+        crossAxisSpacing: 3.w,
+        childAspectRatio: 1.15,
       ),
-      itemBuilder: (context, index) => itemTile(),
+      itemBuilder: (context, index) {
+        final name = items[index];
+        return CategoryGridTile(
+          name: name,
+          onTap: () => onItemTap(context, name),
+        );
+      },
     );
   }
 
-  Widget itemTile() {
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 2.w, vertical: 2.h),
-      child: Container(
-        decoration: BoxDecoration(
-          color: primary,
-          borderRadius: BorderRadius.circular(15),
-        ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            SizedBox(height: 1.h),
-            Container(color: Colors.red, width: 10.w, height: 5.h),
-            Text(
-              "Item",
-              style: TextStyle(
-                fontSize: 20.sp,
-                fontWeight: FontWeight.bold,
-                color: backgroundColor,
-              ),
-            ),
-            SizedBox(height: 1.h),
-          ],
-        ),
+  Widget _customItemGrid(
+    BuildContext context,
+    List<CustomCollectionItem> items,
+  ) {
+    return GridView.builder(
+      padding: EdgeInsets.zero,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: items.length,
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        mainAxisSpacing: 1.5.h,
+        crossAxisSpacing: 3.w,
+        childAspectRatio: 1.15,
       ),
+      itemBuilder: (context, index) {
+        final item = items[index];
+        return CategoryGridTile(
+          name: item.name,
+          onTap: () => onItemTap(context, item.name),
+        );
+      },
+    );
+  }
+
+  void onItemTap(BuildContext context, String name) {
+    sl<GroceryListCubit>().addItem(name);
+    MySnackBar().showSuccess(
+      context: context,
+      message: "Added $name to your grocery list",
     );
   }
 }

--- a/src/lib/features/grocery_list/presentation/pages/collections_page.dart
+++ b/src/lib/features/grocery_list/presentation/pages/collections_page.dart
@@ -1,67 +1,88 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' hide SearchBar;
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:sizer/sizer.dart';
 import 'package:src/config/router.dart';
 import 'package:src/core/presentation/widgets/search_bar.dart';
 import 'package:src/features/grocery_list/data/constants.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_cubit.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_state.dart';
 
 /// Content shown when "Collections" tab is selected on the home screen.
 class CollectionsPage extends StatelessWidget {
   const CollectionsPage({super.key});
 
-  @override
-  Widget build(BuildContext context) {
-    return ListView(
-      padding: EdgeInsets.zero,
-      shrinkWrap: true,
-      physics: const ClampingScrollPhysics(),
-      children: [
-        MySearchBar(),
-        SizedBox(height: 2.h),
-        collection(context),
-      ],
-    );
+  List<String> _visibleCollections(GroceryListState state) {
+    if (!state.hasCustomCollection) {
+      return List<String>.from(collectionNames);
+    }
+    return [customCollectionName, ...collectionNames];
   }
 
-  Widget collection(BuildContext context) {
-    return ListView.builder(
-      padding: EdgeInsets.zero,
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      itemCount: 8,
-      itemBuilder: (context, index) =>
-          collectionCard(context, "title", CupertinoIcons.bag_fill),
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<GroceryListCubit, GroceryListState>(
+      builder: (context, state) {
+        final collections = _visibleCollections(state);
+
+        return Column(
+          children: [
+            MySearchBar(),
+            SizedBox(height: 2.h),
+            Expanded(
+              child: ListView.builder(
+                padding: EdgeInsets.zero,
+                itemCount: collections.length,
+                itemBuilder: (context, index) => collectionCard(
+                  context,
+                  collections[index],
+                  isCustomCollection(collections[index])
+                      ? CupertinoIcons.star_fill
+                      : CupertinoIcons.bag_fill,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 
   Widget collectionCard(BuildContext context, String title, IconData icon) {
     return GestureDetector(
       onTap: () {
-        AppRouter.goTo(context, "categories");
+        AppRouter.goTo(
+          context,
+          'categories/${Uri.encodeComponent(title)}',
+        );
       },
       child: Padding(
         padding: EdgeInsets.symmetric(vertical: 1.5.h),
         child: Container(
-          width: 10.w,
+          width: double.infinity,
           height: 15.h,
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(20),
             color: primary,
           ),
           child: Row(
-            mainAxisAlignment: MainAxisAlignment.start,
             children: [
               SizedBox(width: 6.w),
-              Icon(icon, size: 43.sp, color: secondary),
-              SizedBox(width: 6.w),
-              Text(
-                title,
-                style: TextStyle(
-                  fontSize: 25.sp,
-                  fontWeight: FontWeight.bold,
-                  color: backgroundColor,
+              Icon(icon, size: 36.sp, color: secondary),
+              SizedBox(width: 4.w),
+              Expanded(
+                child: Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 22.sp,
+                    fontWeight: FontWeight.bold,
+                    color: backgroundColor,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
+              SizedBox(width: 4.w),
             ],
           ),
         ),

--- a/src/lib/features/grocery_list/presentation/pages/custom_items.dart
+++ b/src/lib/features/grocery_list/presentation/pages/custom_items.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sizer/sizer.dart';
+import 'package:src/config/injection_dependencies.dart';
 import 'package:src/core/presentation/widgets/search_bar.dart';
 import 'package:src/features/grocery_list/data/constants.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_cubit.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_state.dart';
 import 'package:src/features/grocery_list/presentation/widgets/item_tile.dart';
 import 'package:src/core/presentation/widgets/top.dart';
 
@@ -13,10 +17,11 @@ class CustomItems extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: ListView(
-        padding: EdgeInsets.symmetric(horizontal: 4.w),
-        children: [
-          Column(
+      backgroundColor: backgroundColor,
+      body: BlocBuilder<GroceryListCubit, GroceryListState>(
+        builder: (context, state) {
+          return ListView(
+            padding: EdgeInsets.symmetric(horizontal: 4.w),
             children: [
               Top(
                 color: Colors.black,
@@ -27,23 +32,40 @@ class CustomItems extends StatelessWidget {
               SizedBox(height: 2.h),
               MySearchBar(),
               SizedBox(height: 2.h),
-              itemsList(context),
+              if (state.customCollectionItems.isEmpty)
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 4.h),
+                  child: Center(
+                    child: Text(
+                      'No custom items to edit.',
+                      style: TextStyle(
+                        fontSize: 16.sp,
+                        color: Colors.grey[700],
+                      ),
+                    ),
+                  ),
+                )
+              else
+                ListView.builder(
+                  shrinkWrap: true,
+                  padding: EdgeInsets.zero,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: state.customCollectionItems.length,
+                  itemBuilder: (context, index) {
+                    final item = state.customCollectionItems[index];
+                    return ItemTile(
+                      title: item.name,
+                      isCustom: true,
+                      imageUrl: item.imagePath,
+                      onRemove: () => sl<GroceryListCubit>()
+                          .removeCustomCollectionItem(item.id),
+                    );
+                  },
+                ),
             ],
-          ),
-        ],
+          );
+        },
       ),
-    );
-  }
-
-  Widget itemsList(BuildContext context) {
-    return ListView.builder(
-      shrinkWrap: true,
-      padding: EdgeInsets.zero,
-      physics: const NeverScrollableScrollPhysics(),
-      itemCount: 10,
-      itemBuilder: (context, index) {
-        return ItemTile(title: "Item $index", isCustom: true);
-      },
     );
   }
 }

--- a/src/lib/features/grocery_list/presentation/pages/home_page.dart
+++ b/src/lib/features/grocery_list/presentation/pages/home_page.dart
@@ -57,7 +57,7 @@ class _HomePageState extends State<HomePage> {
                 onPageChanged: (index) {
                   setState(() => currentPage = index);
                 },
-                children: const [CollectionsPage(), MyGroceryListPage()],
+                children: [CollectionsPage(), MyGroceryListPage()],
               ),
             ),
           ],
@@ -84,18 +84,22 @@ class _HomePageState extends State<HomePage> {
           color: isSelected ? primary : Colors.grey.shade300,
           borderRadius: BorderRadius.circular(10000),
         ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              text,
-              style: TextStyle(
-                color: isSelected ? Colors.white : Colors.grey.shade700,
-                fontSize: 16.sp,
-                fontWeight: FontWeight.bold,
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 2.w),
+          child: Center(
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                text,
+                style: TextStyle(
+                  color: isSelected ? Colors.white : Colors.grey.shade700,
+                  fontSize: 16.sp,
+                  fontWeight: FontWeight.bold,
+                ),
+                maxLines: 1,
               ),
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/src/lib/features/grocery_list/presentation/pages/my_grocery_list_page.dart
+++ b/src/lib/features/grocery_list/presentation/pages/my_grocery_list_page.dart
@@ -1,86 +1,51 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:sizer/sizer.dart';
 import 'package:src/core/presentation/widgets/search_bar.dart';
-import 'package:src/features/grocery_list/data/constants.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_cubit.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_state.dart';
 import 'package:src/features/grocery_list/presentation/widgets/item_tile.dart';
 
 /// Content shown when "My Grocery List" tab is selected on the home screen.
-class MyGroceryListPage extends StatefulWidget {
+class MyGroceryListPage extends StatelessWidget {
   const MyGroceryListPage({super.key});
 
   @override
-  State<MyGroceryListPage> createState() => _MyGroceryListPageState();
-}
-
-class _MyGroceryListPageState extends State<MyGroceryListPage> {
-  int quantity = 0;
-
-  void incrementQuantity() {
-    setState(() {
-      quantity++;
-    });
-  }
-
-  void decrementQuantity() {
-    setState(() {
-      quantity--;
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return ListView(
-      padding: EdgeInsets.zero,
-      shrinkWrap: true,
-      physics: const ClampingScrollPhysics(),
-      children: [
-        MySearchBar(),
-        SizedBox(height: 2.h),
-        item(context),
-      ],
-    );
-  }
-
-  Widget item(BuildContext context) {
-    return ListView.builder(
-      padding: EdgeInsets.zero,
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      itemCount: 8,
-      itemBuilder: (context, index) => ItemTile(title: 'title'),
-    );
-  }
-
-  Widget searchBar(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 4.w),
-      child: Row(
-        children: [
-          Expanded(
-            child: CupertinoSearchTextField(
-              prefixIcon: Icon(
-                CupertinoIcons.search,
-                color: primary,
-                size: 18.sp,
-              ),
-              placeholder: 'Search an Item',
-              placeholderStyle: TextStyle(
-                fontSize: 16.5.sp,
-                color: Colors.grey[700],
-              ),
-              padding: EdgeInsets.symmetric(horizontal: 3.w, vertical: 1.2.h),
-              style: TextStyle(color: Colors.black),
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(1000),
-                border: Border.all(color: secondary, width: 0.8.w),
-              ),
-              onChanged: (value) {},
+    return BlocBuilder<GroceryListCubit, GroceryListState>(
+      builder: (context, state) {
+        return Column(
+          children: [
+            MySearchBar(),
+            SizedBox(height: 2.h),
+            Expanded(
+              child: state.items.isEmpty
+                  ? Center(
+                      child: Text(
+                        'Your grocery list is empty.\nTap an item in a collection to add it.',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 16.sp,
+                          color: Colors.grey[700],
+                        ),
+                      ),
+                    )
+                  : ListView.builder(
+                      padding: EdgeInsets.zero,
+                      itemCount: state.items.length,
+                      itemBuilder: (context, index) {
+                        final item = state.items[index];
+                        return ItemTile(
+                          title: item.name,
+                          itemId: item.id,
+                          quantity: item.quantity,
+                        );
+                      },
+                    ),
             ),
-          ),
-        ],
-      ),
+          ],
+        );
+      },
     );
   }
 }

--- a/src/lib/features/grocery_list/presentation/routes.dart
+++ b/src/lib/features/grocery_list/presentation/routes.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
-import 'package:src/features/example_feature/presentation/cubits/todo_cubit.dart';
+import 'package:src/features/grocery_list/data/constants.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_cubit.dart';
 import 'package:src/features/grocery_list/presentation/pages/add_item.dart';
 import 'package:src/features/grocery_list/presentation/pages/categories.dart';
 import 'package:src/features/grocery_list/presentation/pages/custom_items.dart';
@@ -12,22 +13,33 @@ import '../../../config/injection_dependencies.dart';
 var groceryListRoutes = GoRoute(
   path: '/grocery_home',
   builder: (_, __) {
-    return MultiBlocProvider(
-      providers: [BlocProvider.value(value: sl<TodoCubit>())],
-      child: HomePage(),
+    return BlocProvider.value(
+      value: sl<GroceryListCubit>(),
+      child: const HomePage(),
     );
   },
   routes: [
     GoRoute(
-      path: "categories",
-      builder: (_, __) {
-        return Categories();
+      path: "categories/:collectionName",
+      builder: (context, state) {
+        final collectionName = Uri.decodeComponent(
+          state.pathParameters['collectionName'] ?? collectionNames.first,
+        );
+        return BlocProvider.value(
+          value: sl<GroceryListCubit>(),
+          child: Categories(
+            collectionName: collectionName,
+          ),
+        );
       },
       routes: [
         GoRoute(
           path: "custom_items",
           builder: (_, __) {
-            return CustomItems();
+            return BlocProvider.value(
+              value: sl<GroceryListCubit>(),
+              child: const CustomItems(),
+            );
           },
           routes: [
             GoRoute(
@@ -43,7 +55,10 @@ var groceryListRoutes = GoRoute(
     GoRoute(
       path: "add_item",
       builder: (_, __) {
-        return AddItem();
+        return BlocProvider.value(
+          value: sl<GroceryListCubit>(),
+          child: const AddItem(),
+        );
       },
     ),
     GoRoute(

--- a/src/lib/features/grocery_list/presentation/widgets/category_grid_tile.dart
+++ b/src/lib/features/grocery_list/presentation/widgets/category_grid_tile.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:sizer/sizer.dart';
+import 'package:src/features/grocery_list/data/constants.dart';
+
+/// Grid card for collection items when no product image is available.
+class CategoryGridTile extends StatelessWidget {
+  const CategoryGridTile({
+    super.key,
+    required this.name,
+    required this.onTap,
+  });
+
+  final String name;
+  final VoidCallback onTap;
+
+  String get _initial {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return '?';
+    return trimmed[0].toUpperCase();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(15),
+        child: Ink(
+          decoration: BoxDecoration(
+            color: primary,
+            borderRadius: BorderRadius.circular(15),
+            border: Border.all(color: secondary.withValues(alpha: 0.6)),
+          ),
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 3.w, vertical: 2.h),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                CircleAvatar(
+                  radius: 5.w,
+                  backgroundColor: secondary,
+                  child: Text(
+                    _initial,
+                    style: TextStyle(
+                      fontSize: 18.sp,
+                      fontWeight: FontWeight.bold,
+                      color: primary,
+                    ),
+                  ),
+                ),
+                SizedBox(height: 1.h),
+                Text(
+                  name,
+                  style: TextStyle(
+                    fontSize: 14.sp,
+                    fontWeight: FontWeight.bold,
+                    color: backgroundColor,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/src/lib/features/grocery_list/presentation/widgets/item_tile.dart
+++ b/src/lib/features/grocery_list/presentation/widgets/item_tile.dart
@@ -1,130 +1,84 @@
+import 'dart:io';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sizer/sizer.dart';
+import 'package:src/config/injection_dependencies.dart';
 import 'package:src/config/router.dart';
 import 'package:src/features/grocery_list/data/constants.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_cubit.dart';
 
-class ItemTile extends StatefulWidget {
+class ItemTile extends StatelessWidget {
   const ItemTile({
     super.key,
     required this.title,
     this.isHistory = false,
     this.isCustom = false,
+    this.itemId,
+    this.quantity = 0,
+    this.imageUrl,
+    this.onRemove,
   });
+
   final String title;
   final bool isHistory;
   final bool isCustom;
+  final String? itemId;
+  final int quantity;
+  final String? imageUrl;
+  final VoidCallback? onRemove;
 
-  @override
-  _ItemTileState createState() => _ItemTileState();
-}
+  bool get _usesGroceryListState => itemId != null && !isHistory && !isCustom;
+  bool get _hasImage => imageUrl != null && imageUrl!.isNotEmpty;
 
-class _ItemTileState extends State<ItemTile> {
-  int quantity = 0;
+  GroceryListCubit get _cubit => sl<GroceryListCubit>();
 
-  void incrementQuantity() {
-    setState(() {
-      quantity++;
-    });
-  }
-
-  void decrementQuantity() {
-    setState(() {
-      quantity--;
-    });
+  String get _initial {
+    final trimmed = title.trim();
+    if (trimmed.isEmpty) return '?';
+    return trimmed[0].toUpperCase();
   }
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => widget.isCustom
-          ? AppRouter.goTo(context, "edit_item")
-          : showActionSheet(context, widget.title),
+      onTap: () {
+        if (isCustom) {
+          AppRouter.goTo(context, "edit_item");
+          return;
+        }
+        if (_usesGroceryListState) {
+          _showActionSheet(context, title);
+        }
+      },
       child: Padding(
-        padding: EdgeInsets.symmetric(vertical: 1.5.h),
+        padding: EdgeInsets.symmetric(vertical: 1.h),
         child: Container(
-          padding: EdgeInsets.symmetric(horizontal: 6.w),
+          padding: EdgeInsets.symmetric(horizontal: 4.w, vertical: 1.5.h),
           width: double.infinity,
-          height: 13.h,
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(20),
             color: primary,
+            border: Border.all(color: secondary.withValues(alpha: 0.5)),
           ),
           child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Row(
-                children: [
-                  Container(
-                    width: 20.w,
-                    height: 8.h,
-                    decoration: BoxDecoration(color: secondary),
+              _buildLeading(),
+              SizedBox(width: 3.w),
+              Expanded(
+                child: Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 18.sp,
+                    fontWeight: FontWeight.bold,
+                    color: backgroundColor,
                   ),
-                  SizedBox(width: 6.w),
-                  Text(
-                    widget.title,
-                    style: TextStyle(
-                      fontSize: 20.sp,
-                      fontWeight: FontWeight.bold,
-                      color: backgroundColor,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (!widget.isHistory && !widget.isCustom)
-                    GestureDetector(
-                      onTap: () {
-                        decrementQuantity();
-                      },
-                      child: Icon(
-                        CupertinoIcons.minus_circle_fill,
-                        size: 25.sp,
-                        color: secondary,
-                      ),
-                    ),
-                  if (!widget.isCustom)
-                    SizedBox(
-                      width: 13.w,
-                      child: Center(
-                        child: Text(
-                          quantity.toString(),
-                          style: TextStyle(
-                            fontSize: 20.sp,
-                            color: backgroundColor,
-                          ),
-                        ),
-                      ),
-                    ),
-                  if (widget.isCustom)
-                    GestureDetector(
-                      onTap: () => _showDeleteDialog(context),
-                      child: Icon(
-                        CupertinoIcons.xmark_circle_fill,
-                        size: 25.sp,
-                        color: secondary,
-                      ),
-                    ),
-                  if (widget.isHistory || widget.isCustom)
-                    SizedBox(width: 9.5.w),
-                  if (!widget.isHistory && !widget.isCustom)
-                    GestureDetector(
-                      onTap: () {
-                        incrementQuantity();
-                      },
-                      child: Icon(
-                        CupertinoIcons.plus_circle_fill,
-                        size: 25.sp,
-                        color: secondary,
-                      ),
-                    ),
-                ],
-              ),
+              _buildTrailing(context),
             ],
           ),
         ),
@@ -132,22 +86,122 @@ class _ItemTileState extends State<ItemTile> {
     );
   }
 
+  Widget _buildLeading() {
+    if (_hasImage) {
+      final source = imageUrl!;
+      final isNetwork = source.startsWith('http');
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(12),
+        child: isNetwork
+            ? Image.network(
+                source,
+                width: 14.w,
+                height: 14.w,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => _buildInitialAvatar(),
+              )
+            : Image.file(
+                File(source),
+                width: 14.w,
+                height: 14.w,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => _buildInitialAvatar(),
+              ),
+      );
+    }
+    return _buildInitialAvatar();
+  }
+
+  Widget _buildInitialAvatar() {
+    return CircleAvatar(
+      radius: 6.w,
+      backgroundColor: secondary,
+      child: Text(
+        _initial,
+        style: TextStyle(
+          fontSize: 16.sp,
+          fontWeight: FontWeight.bold,
+          color: primary,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTrailing(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (!isHistory && !isCustom)
+          GestureDetector(
+            onTap: _decrement,
+            child: Icon(
+              CupertinoIcons.minus_circle_fill,
+              size: 25.sp,
+              color: secondary,
+            ),
+          ),
+        if (!isCustom)
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: 2.w),
+            child: Text(
+              quantity.toString(),
+              style: TextStyle(
+                fontSize: 20.sp,
+                fontWeight: FontWeight.bold,
+                color: backgroundColor,
+              ),
+            ),
+          ),
+        if (isCustom)
+          GestureDetector(
+            onTap: () => _showDeleteDialog(context),
+            child: Icon(
+              CupertinoIcons.xmark_circle_fill,
+              size: 25.sp,
+              color: secondary,
+            ),
+          ),
+        if (!isHistory && !isCustom)
+          GestureDetector(
+            onTap: _increment,
+            child: Icon(
+              CupertinoIcons.plus_circle_fill,
+              size: 25.sp,
+              color: secondary,
+            ),
+          ),
+      ],
+    );
+  }
+
+  void _increment() {
+    if (_usesGroceryListState) {
+      _cubit.incrementQuantity(itemId!);
+    }
+  }
+
+  void _decrement() {
+    if (_usesGroceryListState) {
+      _cubit.decrementQuantity(itemId!);
+    }
+  }
+
   void _showDeleteDialog(BuildContext context) {
     showCupertinoDialog<void>(
       context: context,
-      builder: (context) => CupertinoAlertDialog(
+      builder: (dialogContext) => CupertinoAlertDialog(
         title: const Text('Remove item'),
-        content: Text('Remove "${widget.title}" from custom items?'),
+        content: Text('Remove "$title" from custom items?'),
         actions: [
           CupertinoDialogAction(
-            onPressed: () => Navigator.of(context).pop(),
+            onPressed: () => Navigator.of(dialogContext).pop(),
             child: const Text('Cancel'),
           ),
           CupertinoDialogAction(
             isDestructiveAction: true,
             onPressed: () {
-              Navigator.of(context).pop();
-              // TODO: delete item when backend is ready
+              Navigator.of(dialogContext).pop();
+              onRemove?.call();
             },
             child: const Text('Remove'),
           ),
@@ -156,10 +210,12 @@ class _ItemTileState extends State<ItemTile> {
     );
   }
 
-  void showActionSheet(BuildContext context, String itemTitle) {
+  void _showActionSheet(BuildContext context, String itemTitle) {
+    final groceryItemId = itemId;
+
     showCupertinoModalPopup<void>(
       context: context,
-      builder: (BuildContext context) => CupertinoActionSheet(
+      builder: (sheetContext) => CupertinoActionSheet(
         title: Text(
           itemTitle,
           style: TextStyle(
@@ -170,23 +226,25 @@ class _ItemTileState extends State<ItemTile> {
         actions: <CupertinoActionSheetAction>[
           CupertinoActionSheetAction(
             onPressed: () {
-              context.pop();
-              // TODO: Edit item
+              sheetContext.pop();
+              // TODO: Mark as completed
             },
             child: const Text('Mark as completed'),
           ),
           CupertinoActionSheetAction(
             isDestructiveAction: true,
             onPressed: () {
-              context.pop();
-              // TODO: Delete item
+              if (groceryItemId != null) {
+                _cubit.removeItem(groceryItemId);
+              }
+              sheetContext.pop();
             },
             child: const Text('Remove from list'),
           ),
         ],
         cancelButton: CupertinoActionSheetAction(
           isDefaultAction: true,
-          onPressed: () => context.pop(),
+          onPressed: () => sheetContext.pop(),
           child: const Text('Cancel'),
         ),
       ),

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   url_launcher: ^6.3.1
   equatable: ^2.0.8
   fl_chart: ^0.69.0
+  top_snackbar_flutter: ^3.3.0
 
 dev_dependencies:
   flutter_test:

--- a/src/test/features/grocery_list/grocery_list_cubit_test.dart
+++ b/src/test/features/grocery_list/grocery_list_cubit_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:src/features/grocery_list/presentation/cubits/grocery_list_cubit.dart';
+
+void main() {
+  group('GroceryListCubit', () {
+    late GroceryListCubit cubit;
+
+    setUp(() {
+      cubit = GroceryListCubit();
+    });
+
+    tearDown(() {
+      cubit.close();
+    });
+
+    test('adds item with trimmed name', () {
+      expect(cubit.addItem('  Milk  '), isTrue);
+      expect(cubit.state.items.length, 1);
+      expect(cubit.state.items.first.name, 'Milk');
+      expect(cubit.state.items.first.quantity, 1);
+    });
+
+    test('rejects empty item names', () {
+      expect(cubit.addItem('   '), isFalse);
+      expect(cubit.state.items, isEmpty);
+    });
+
+    test('increments quantity when same item is added again', () {
+      expect(cubit.addItem('Eggs'), isTrue);
+      expect(cubit.addItem('eggs'), isTrue);
+      expect(cubit.state.items.length, 1);
+      expect(cubit.state.items.first.quantity, 2);
+    });
+
+    test('supports multiple unique items', () {
+      expect(cubit.addItem('Milk'), isTrue);
+      expect(cubit.addItem('Eggs'), isTrue);
+      expect(cubit.addItem('Bread'), isTrue);
+      expect(cubit.state.items.length, 3);
+    });
+
+    test('incrementQuantity increases count', () {
+      cubit.addItem('Milk');
+      final id = cubit.state.items.first.id;
+      cubit.incrementQuantity(id);
+      expect(cubit.state.items.first.quantity, 2);
+    });
+
+    test('decrementQuantity removes item when quantity reaches zero', () {
+      cubit.addItem('Milk');
+      final id = cubit.state.items.first.id;
+      cubit.decrementQuantity(id);
+      expect(cubit.state.items, isEmpty);
+    });
+
+    test('removeItem removes by id', () {
+      cubit.addItem('Milk');
+      final id = cubit.state.items.first.id;
+      cubit.removeItem(id);
+      expect(cubit.state.items, isEmpty);
+    });
+
+    test('addCustomCollectionItem creates custom collection entry', () {
+      expect(cubit.addCustomCollectionItem('Protein Powder'), isTrue);
+      expect(cubit.state.hasCustomCollection, isTrue);
+      expect(cubit.state.customCollectionItems.first.name, 'Protein Powder');
+    });
+
+    test('rejects duplicate custom collection items', () {
+      cubit.addCustomCollectionItem('Honey');
+      expect(cubit.addCustomCollectionItem('honey'), isFalse);
+      expect(cubit.state.customCollectionItems.length, 1);
+    });
+
+    test('removeCustomCollectionItem clears custom collection', () {
+      cubit.addCustomCollectionItem('Honey');
+      final id = cubit.state.customCollectionItems.first.id;
+      cubit.removeCustomCollectionItem(id);
+      expect(cubit.state.hasCustomCollection, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #625 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Added GroceryListCubit and GroceryListState to manage active grocery list items and custom collection items in memory.
- Wired My Grocery List to real state: items from collections appear in the list with quantity controls, empty-state messaging, and remove-from-list via action sheet.
- Populated Collections and Categories with built-in collection data (Vegetables, Fruits, Dairy, etc.); tapping an item adds it to the grocery list (duplicate names merge quantity).
- Implemented Custom collection flow: add items from the home + button, show Custom in collections when items exist, browse/delete custom items, and duplicate-name validation with snackbar feedback.
- Refactored ItemTile to use shared cubit state (quantity +/-, remove, optional image/initial avatar) and added CategoryGridTile for category grids.
- Registered GroceryListCubit in DI, updated grocery routes (categories/:collectionName, BlocProvider), and added GroceryListCubit unit tests.


### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
The grocery list UI was mostly static placeholders (hardcoded titles, local tile quantity, no real add/remove flow). This change connects collections → add item → My Grocery List so users can build and manage a list from the app, matching the wireframes for browsing collections and viewing the active list. Persistence, history, and “mark as completed” are follow-ups.



---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] Branch is up to date with base branch

---

## 👀 Reviewers
<!-- Tag team members for review -->
@Solimar-Cruz @Kay9876 @LuisJCruz 
