### PR TITLE
Add Route and Navigation Link for Alerts & Notifications Screen

### DIFF
--- a/src/lib/core/presentation/pages/home_page.dart
+++ b/src/lib/core/presentation/pages/home_page.dart
@@ -15,9 +15,7 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(
         title: Text(
           "Home Page",
-          style: Theme.of(context)
-              .textTheme
-              .displayMedium,
+          style: Theme.of(context).textTheme.displayMedium,
         ),
       ),
       body: Center(
@@ -37,7 +35,7 @@ class HomePage extends StatelessWidget {
             buildButton(context, "Alerts", () {
               AppRouter.goTo(context, "alerts_home");
             }),
-            
+
             Text("This is the main page of the app"),
             SizedBox(height: 20),
 

--- a/src/lib/core/presentation/routes.dart
+++ b/src/lib/core/presentation/routes.dart
@@ -26,19 +26,12 @@ const List<MainNavTab> _mainTabs = [
     icon: Icons.bar_chart,
     rootPath: '/home/reports',
   ),
-  MainNavTab(label: 'Alerts', icon: Icons.notifications, rootPath: '/alerts'),
+  MainNavTab(
+    label: 'Alerts',
+    icon: Icons.notifications,
+    rootPath: '/alerts_home',
+  ),
 ];
-
-class _AlertsPageStub extends StatelessWidget {
-  const _AlertsPageStub();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('TO DO: Route Alerts screen')),
-    );
-  }
-}
 
 var mainRoutes = StatefulShellRoute.indexedStack(
   builder: (context, state, navigationShell) {
@@ -72,10 +65,6 @@ var mainRoutes = StatefulShellRoute.indexedStack(
     StatefulShellBranch(routes: [groceryListRoutes]),
     StatefulShellBranch(routes: [inventoryRoutes]),
     StatefulShellBranch(routes: [reportsOverviewRoute]),
-    StatefulShellBranch(
-      routes: [
-        GoRoute(path: '/alerts', builder: (_, __) => const _AlertsPageStub()),
-      ],
-    ),
+    StatefulShellBranch(routes: [alertsFeedRoutes]),
   ],
 );

--- a/src/lib/features/alerts_feed/presentation/pages/alerts_home.dart
+++ b/src/lib/features/alerts_feed/presentation/pages/alerts_home.dart
@@ -18,7 +18,8 @@ class AlertsHome extends StatelessWidget {
           children: [
             Top(
               color: Colors.black,
-              leftButton: () => Navigator.pop(context),
+              leftButton: () {},
+              leftButtonText: " ",
               title: "Alerts",
               textStyle: Theme.of(context).textTheme.displayLarge,
               iconColor: AppTheme.primaryColor,

--- a/src/lib/features/alerts_feed/presentation/routes.dart
+++ b/src/lib/features/alerts_feed/presentation/routes.dart
@@ -6,10 +6,5 @@ import 'pages/alerts_home.dart';
 
 var alertsFeedRoutes = GoRoute(
   path: '/alerts_home',
-  builder: (_, __) {
-    return MultiBlocProvider(
-      providers: [BlocProvider.value(value: sl<TodoCubit>())],
-      child: AlertsHome(),
-    );
-  },
+  builder: (_, __) => const AlertsHome(),
 );


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #654

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Removed the unnecessary `TodoCubit` provider.
- Replaced the `_AlertsPageStub` placeholder in the main `GoRouter` configuration (`router.dart`) with the actual `alertsFeedRoutes`.
- Passed an empty function and a blank space (`" "`) as `leftButtonText` to the `Top` widget in `AlertsHome`. This effectively hides the back button since this screen is now a root navigation tab.

### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
The Alerts & Notifications screen was fully implemented but completely disconnected from the main application flow. This PR provides the necessary entry points so the team and reviewers can access the feature.

---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] Branch is up to date with base branch

---

## 🧪 Testing (if applicable)
<!-- Describe how you tested these changes -->
### Test Steps:
1. Launch the app and go to the main Home Page.
2. Tap the Alerts icon in the bottom navigation bar.
3. Verify that the app routes to the `AlertsHome` screen successfully.
4. Verify that the `Top` widget does not display a back arrow and the title is centered.

### Test Results:
<!-- What was the outcome? -->
Navigation to the Alerts screen works perfectly. The screen loads without routing errors, and the back arrow is successfully hidden without breaking the `Top` widget's constraints.

---

## 📸 Screenshots/Videos (if applicable)
<!-- Add screenshots or videos demonstrating the changes -->
<img width="381" height="854" alt="image" src="https://github.com/user-attachments/assets/df9a5bbd-582c-4f22-a209-a8fa7ca00a8f" />



---

## 👀 Reviewers
<!-- Tag team members for review -->
@LuisJCruz  @Kay9876 @Solimar-Cruz 
