### PR TITLE
Fix Dashboard Filter UI and Empty State

### DIFF
--- a/src/lib/core/presentation/pages/home_dashboard_page.dart
+++ b/src/lib/core/presentation/pages/home_dashboard_page.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sizer/sizer.dart';
@@ -38,6 +39,14 @@ class HomeDashboardPage extends StatelessWidget {
                 if (state is DashboardLoaded) {
                   final items = state.items;
 
+                  // Show empty state if isEmpty is true or no items exist
+                  if (isEmpty || items.isEmpty) {
+                    return SingleChildScrollView(
+                      padding: EdgeInsets.symmetric(horizontal: 4.w),
+                      child: _buildEmptyState(context),
+                    );
+                  }
+
                   final totalItems = items.length;
                   final totalValue = items.fold<double>(
                     0,
@@ -70,10 +79,9 @@ class HomeDashboardPage extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        SizedBox(height: 2.h),
         Center(
           child: Padding(
-            padding: EdgeInsets.symmetric(vertical: 10.h),
+            padding: EdgeInsets.symmetric(vertical: 14.h),
             child: Column(
               children: [
                 Text(
@@ -82,7 +90,7 @@ class HomeDashboardPage extends StatelessWidget {
                     fontSize: 18.sp,
                   ),
                 ),
-                SizedBox(height: 1.h),
+                SizedBox(height: 0.8.h),
                 Text(
                   'Start building your inventory.',
                   style: theme.textTheme.bodyMedium,
@@ -90,7 +98,7 @@ class HomeDashboardPage extends StatelessWidget {
                 SizedBox(height: 3.h),
                 ElevatedButton(
                   onPressed: () {
-                    // Add item action
+                    context.go('/inventory');
                   },
                   style: ElevatedButton.styleFrom(
                     elevation: 0,
@@ -98,16 +106,13 @@ class HomeDashboardPage extends StatelessWidget {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(16),
                     ),
-                    overlayColor: theme.scaffoldBackgroundColor.withOpacity(
-                      0.2,
-                    ),
                     padding: EdgeInsets.symmetric(
                       horizontal: 8.5.w,
                       vertical: 1.3.h,
                     ),
                   ),
                   child: Text(
-                    'Add Item',
+                    'Explore',
                     style: theme.textTheme.displayMedium?.copyWith(
                       fontSize: 16.sp,
                       color: theme.scaffoldBackgroundColor,
@@ -118,33 +123,40 @@ class HomeDashboardPage extends StatelessWidget {
             ),
           ),
         ),
-        SizedBox(height: 15.h),
-        // Stat Cards Row 1
-        Row(
-          children: [
-            Expanded(
-              child: StatCard(label: 'Total Items', value: '0'),
-            ),
-            SizedBox(width: 3.w),
-            Expanded(
-              child: StatCard(label: 'Inventory Value', value: '\$0.00'),
-            ),
-          ],
+        // Blurred Stat Cards
+        ImageFiltered(
+          imageFilter: ImageFilter.blur(sigmaX: 3.0, sigmaY: 3.0),
+          child: Column(
+            children: [
+              // Stat Cards Row 1
+              Row(
+                children: [
+                  Expanded(
+                    child: StatCard(label: 'Total Items', value: '0'),
+                  ),
+                  SizedBox(width: 3.w),
+                  Expanded(
+                    child: StatCard(label: 'Inventory Value', value: '\$0.00'),
+                  ),
+                ],
+              ),
+              SizedBox(height: 1.5.h),
+              // Stat Cards Row 2
+              Row(
+                children: [
+                  Expanded(
+                    child: StatCard(label: 'Pending Alerts', value: '0'),
+                  ),
+                  SizedBox(width: 3.w),
+                  Expanded(
+                    child: StatCard(label: 'Categories Tracked', value: '0'),
+                  ),
+                ],
+              ),
+              SizedBox(height: 2.h),
+            ],
+          ),
         ),
-        SizedBox(height: 1.5.h),
-        // Stat Cards Row 2
-        Row(
-          children: [
-            Expanded(
-              child: StatCard(label: 'Pending Alerts', value: '0'),
-            ),
-            SizedBox(width: 3.w),
-            Expanded(
-              child: StatCard(label: 'Categories Tracked', value: '0'),
-            ),
-          ],
-        ),
-        SizedBox(height: 2.h),
       ],
     );
   }
@@ -155,7 +167,9 @@ class HomeDashboardPage extends StatelessWidget {
     int totalItems,
     double totalValue,
   ) {
-    final reportsNavigate = () => context.go('/home/reports');
+    void reportsNavigate() {
+      context.go('/home/reports');
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/src/lib/core/presentation/pages/home_dashboard_page.dart
+++ b/src/lib/core/presentation/pages/home_dashboard_page.dart
@@ -118,7 +118,7 @@ class HomeDashboardPage extends StatelessWidget {
             ),
           ),
         ),
-        SizedBox(height: 1.5.h),
+        SizedBox(height: 15.h),
         // Stat Cards Row 1
         Row(
           children: [
@@ -162,11 +162,11 @@ class HomeDashboardPage extends StatelessWidget {
       children: [
         SizedBox(height: 2.h),
         Container(
-          margin: EdgeInsets.only(bottom: 2.h),
+          margin: EdgeInsets.only(bottom: 2.5.h),
           padding: const EdgeInsets.all(16),
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.primary,
-            borderRadius: BorderRadius.circular(20),
+            borderRadius: BorderRadius.circular(16),
           ),
           child: _buildFilters(context),
         ),
@@ -314,65 +314,192 @@ class HomeDashboardPage extends StatelessWidget {
   }
 
   Widget _buildFilters(BuildContext context) {
-    String? selectedCategory;
-    String? selectedRoom;
-    DateTime? startDate;
-    DateTime? endDate;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        DropdownButtonFormField<String>(
-          decoration: const InputDecoration(labelText: "Category"),
-          items: ["Electronics", "Furniture", "Clothing"]
-              .map(
-                (category) =>
-                    DropdownMenuItem(value: category, child: Text(category)),
-              )
-              .toList(),
-          onChanged: (value) {
-            selectedCategory = value;
-          },
-        ),
+    final theme = Theme.of(context);
+    return BlocBuilder<DashboardCubit, DashboardState>(
+      builder: (context, state) {
+        String? selectedCategory;
+        String? selectedRoom;
 
-        const SizedBox(height: 8),
+        if (state is DashboardLoaded) {
+          selectedCategory = state.selectedCategory;
+          selectedRoom = state.selectedRoom;
+        }
 
-        DropdownButtonFormField<String>(
-          decoration: const InputDecoration(labelText: "Room"),
-          items: ["Living Room", "Bedroom", "Kitchen"]
-              .map((room) => DropdownMenuItem(value: room, child: Text(room)))
-              .toList(),
-          onChanged: (value) {
-            selectedRoom = value;
-          },
-        ),
-
-        const SizedBox(height: 12),
-
-        Row(
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            ElevatedButton(
-              onPressed: () {
-                context.read<DashboardCubit>().applyFilters(
-                  category: selectedCategory,
-                  room: selectedRoom,
-                  startDate: startDate,
-                  endDate: endDate,
-                );
+            Text(
+              "Category",
+              style: theme.textTheme.displayMedium?.copyWith(
+                color: theme.colorScheme.onPrimary,
+                fontSize: 14.5.sp,
+              ),
+            ),
+            const SizedBox(height: 4),
+            DropdownButtonFormField<String>(
+              initialValue: selectedCategory,
+              decoration: InputDecoration(
+                labelText: "Select a Category",
+                floatingLabelBehavior: FloatingLabelBehavior.never,
+                labelStyle: theme.textTheme.titleLarge?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontSize: 15.sp,
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide.none,
+                ),
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 12,
+                ),
+                fillColor: theme.scaffoldBackgroundColor,
+                filled: true,
+              ),
+              items: ["Electronics", "Furniture", "Clothing"]
+                  .map(
+                    (category) => DropdownMenuItem(
+                      value: category,
+                      child: Text(
+                        category,
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          color: theme.colorScheme.primary,
+                          fontSize: 15.sp,
+                        ),
+                      ),
+                    ),
+                  )
+                  .toList(),
+              selectedItemBuilder: (BuildContext context) {
+                return ["Electronics", "Furniture", "Clothing"]
+                    .map(
+                      (category) => Text(
+                        category,
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          color: theme.colorScheme.primary,
+                          fontSize: 15.sp,
+                        ),
+                      ),
+                    )
+                    .toList();
               },
-              child: const Text("Apply Filters"),
+              onChanged: (value) {
+                context.read<DashboardCubit>().setCategory(value);
+              },
             ),
 
-            const SizedBox(width: 12),
+            const SizedBox(height: 12),
 
-            OutlinedButton(
-              onPressed: () {
-                context.read<DashboardCubit>().clearFilters();
+            Text(
+              "Room",
+              style: theme.textTheme.displayMedium?.copyWith(
+                color: theme.colorScheme.onPrimary,
+                fontSize: 14.5.sp,
+              ),
+            ),
+            const SizedBox(height: 4),
+            DropdownButtonFormField<String>(
+              initialValue: selectedRoom,
+              decoration: InputDecoration(
+                labelText: "Select a Room",
+                floatingLabelBehavior: FloatingLabelBehavior.never,
+                labelStyle: theme.textTheme.titleLarge?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontSize: 15.sp,
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide.none,
+                ),
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 12,
+                ),
+                fillColor: theme.scaffoldBackgroundColor,
+                filled: true,
+              ),
+              items: ["Living Room", "Bedroom", "Kitchen"]
+                  .map(
+                    (room) => DropdownMenuItem(
+                      value: room,
+                      child: Text(
+                        room,
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          color: theme.colorScheme.primary,
+                          fontSize: 15.sp,
+                        ),
+                      ),
+                    ),
+                  )
+                  .toList(),
+              selectedItemBuilder: (BuildContext context) {
+                return ["Living Room", "Bedroom", "Kitchen"]
+                    .map(
+                      (room) => Text(
+                        room,
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          color: theme.colorScheme.primary,
+                          fontSize: 15.sp,
+                        ),
+                      ),
+                    )
+                    .toList();
               },
-              child: const Text("Clear"),
+              onChanged: (value) {
+                context.read<DashboardCubit>().setRoom(value);
+              },
+            ),
+
+            const SizedBox(height: 12),
+
+            Row(
+              children: [
+                ElevatedButton(
+                  onPressed: () {
+                    context.read<DashboardCubit>().applyFilters(
+                      category: selectedCategory,
+                      room: selectedRoom,
+                    );
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: theme.colorScheme.secondary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                  ),
+                  child: Text(
+                    "Apply Filters",
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      color: theme.scaffoldBackgroundColor,
+                      fontSize: 15.sp,
+                    ),
+                  ),
+                ),
+
+                const SizedBox(width: 12),
+
+                OutlinedButton(
+                  onPressed: () {
+                    context.read<DashboardCubit>().clearFilters();
+                  },
+                  style: OutlinedButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                  ),
+                  child: Text(
+                    "Clear",
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      color: theme.scaffoldBackgroundColor,
+                      fontSize: 15.sp,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ],
-        ),
-      ],
+        );
+      },
     );
   }
 

--- a/src/lib/core/presentation/widgets/dashboard_card.dart
+++ b/src/lib/core/presentation/widgets/dashboard_card.dart
@@ -27,7 +27,7 @@ class DashboardCard extends StatelessWidget {
       height: height ?? 22.h,
       decoration: BoxDecoration(
         color: theme.colorScheme.primary,
-        borderRadius: BorderRadius.circular(15),
+        borderRadius: BorderRadius.circular(16),
       ),
       child: Padding(
         padding: padding ?? EdgeInsets.all(3.5.w),

--- a/src/lib/core/presentation/widgets/dashboard_card.dart
+++ b/src/lib/core/presentation/widgets/dashboard_card.dart
@@ -38,8 +38,8 @@ class DashboardCard extends StatelessWidget {
             Text(
               title,
               style: theme.textTheme.displayMedium?.copyWith(
-                fontSize: 16.sp,
                 color: theme.scaffoldBackgroundColor,
+                fontSize: 16.sp,
               ),
             ),
             SizedBox(height: 2.5.h),

--- a/src/lib/core/presentation/widgets/stat_card.dart
+++ b/src/lib/core/presentation/widgets/stat_card.dart
@@ -41,8 +41,8 @@ class StatCard extends StatelessWidget {
               label,
               textAlign: TextAlign.center,
               style: theme.textTheme.displayMedium?.copyWith(
-                fontSize: 16.sp,
                 color: theme.scaffoldBackgroundColor,
+                fontSize: 16.sp,
               ),
             ),
             // Spacer to push value to vertical center

--- a/src/lib/core/presentation/widgets/stat_card.dart
+++ b/src/lib/core/presentation/widgets/stat_card.dart
@@ -29,7 +29,7 @@ class StatCard extends StatelessWidget {
       height: size,
       decoration: BoxDecoration(
         color: theme.colorScheme.primary,
-        borderRadius: BorderRadius.circular(15),
+        borderRadius: BorderRadius.circular(16),
       ),
       child: Padding(
         padding: EdgeInsets.symmetric(horizontal: 2.w, vertical: 2.h),

--- a/src/lib/features/dashboard/presentation/cubit/dashboard_cubit.dart
+++ b/src/lib/features/dashboard/presentation/cubit/dashboard_cubit.dart
@@ -124,4 +124,36 @@ class DashboardCubit extends Cubit<DashboardState> {
       emit(DashboardError("Failed to refresh dashboard"));
     }
   }
+
+  void setCategory(String? category) {
+    _category = category;
+    if (state is DashboardLoaded) {
+      final currentState = state as DashboardLoaded;
+      emit(
+        DashboardLoaded(
+          currentState.items,
+          selectedCategory: _category,
+          selectedRoom: _room,
+          startDate: _startDate,
+          endDate: _endDate,
+        ),
+      );
+    }
+  }
+
+  void setRoom(String? room) {
+    _room = room;
+    if (state is DashboardLoaded) {
+      final currentState = state as DashboardLoaded;
+      emit(
+        DashboardLoaded(
+          currentState.items,
+          selectedCategory: _category,
+          selectedRoom: _room,
+          startDate: _startDate,
+          endDate: _endDate,
+        ),
+      );
+    }
+  }
 }


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #687
Closes #688 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Updated the filter widget design to better align with the Home/Dashboard UI.
- Added state persistence to the filter widget so selected filter settings are maintained.
- Fixed dashboard empty state visibility and improved its styling for a cleaner, more consistent experience.
- Changed the empty state “Add Item” button to “Explore” and rerouted it to the Inventory page.

### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
Improve the Home/Dashboard experience by making the filter widget visually consistent with the rest of the page, preserving selected filter state, and ensuring the empty state displays correctly with clearer styling and navigation.

---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated
- [x] Branch is up to date with base branch

---

## 🧪 Testing (if applicable)
<!-- Describe how you tested these changes -->
### Test Steps:
1. Run the app (`flutter run`) on a simulator/device.
2. Open the Home/Dashboard page and verify the filter widget matches the Home/Dashboard design.
3. Select different filter options and confirm the selected state persists as expected.
4. Toggle or pass `isEmpty: true`, then confirm the empty state displays correctly and the “Explore” button routes to the Inventory page.

### Test Results:
<!-- What was the outcome? -->
The filter widget now matches the Home/Dashboard design and preserves selected filter state. The dashboard empty state displays correctly when `isEmpty` is active, uses improved styling, and the “Explore” button routes users to the Inventory page.

---

## 📸 Screenshots/Videos (if applicable)
<!-- Add screenshots or videos demonstrating the changes -->
<img width="327" height="711" alt="home-dashboard-filter" src="https://github.com/user-attachments/assets/559071c0-cc11-4dd2-9dca-84e64ac52c11" />
<img width="327" height="711" alt="home-dashboard-empty" src="https://github.com/user-attachments/assets/7905264d-7076-49f7-a609-50f161e42061" />

---

## 👀 Reviewers
<!-- Tag team members for review -->
@Kay9876 @LuisJCruz @FabianVelezOcasio 
