### PR TITLE
feat: implement sharing use cases(#672)

### DIFF
--- a/src/lib/config/injection_dependencies.dart
+++ b/src/lib/config/injection_dependencies.dart
@@ -39,6 +39,21 @@ import 'package:src/features/core_inventory/domain/usecases/delete_inventory_ite
 import 'package:src/features/core_inventory/presentation/cubits/inventory_cubit.dart';
 import 'package:src/features/dashboard/domain/repositories/dashboard_repositories.dart';
 import 'package:src/features/dashboard/data/dashboard_repository_impl.dart';
+import 'package:src/features/sharing_budget/data/datasources/Invitation_remote_data_source.dart';
+import 'package:src/features/sharing_budget/data/datasources/household_remote_data_source.dart';
+import 'package:src/features/sharing_budget/data/repositories/sharing_repository_impl.dart';
+import 'package:src/features/sharing_budget/domain/repositories/sharing_repository.dart';
+import 'package:src/features/sharing_budget/domain/usecases/accept_roommate_invite.dart';
+import 'package:src/features/sharing_budget/domain/usecases/add_household_member.dart';
+import 'package:src/features/sharing_budget/domain/usecases/create_household.dart';
+import 'package:src/features/sharing_budget/domain/usecases/get_household_by_id.dart';
+import 'package:src/features/sharing_budget/domain/usecases/get_household_invites.dart';
+import 'package:src/features/sharing_budget/domain/usecases/get_household_members.dart';
+import 'package:src/features/sharing_budget/domain/usecases/get_invite_by_id.dart';
+import 'package:src/features/sharing_budget/domain/usecases/reject_roommate_invite.dart';
+import 'package:src/features/sharing_budget/domain/usecases/remove_household_member.dart';
+import 'package:src/features/sharing_budget/domain/usecases/send_roommate_invite.dart';
+import 'package:src/features/sharing_budget/domain/usecases/validate_household_membership.dart';
 
 final sl = GetIt.instance;
 
@@ -160,7 +175,48 @@ Future<void> initializeDependencies() async {
   // ...
 
   /// Sharing and Budget
-  // ...
+
+  // Data Sources
+  sl.registerLazySingleton<HouseholdRemoteDataSource>(
+    () => HouseholdRemoteDataSource(sl<SupabaseClient>()),
+  );
+
+  sl.registerLazySingleton<InvitationRemoteDataSource>(
+    () => InvitationRemoteDataSource(sl<SupabaseClient>()),
+  );
+
+  // Repositories
+  sl.registerLazySingleton<SharingRepository>(
+    () => SharingRepositoryImpl(
+      householdRemoteDataSource: sl<HouseholdRemoteDataSource>(),
+      invitationRemoteDataSource: sl<InvitationRemoteDataSource>(),
+    ),
+  );
+
+  // Usecases
+  sl.registerLazySingleton<CreateHousehold>(() => CreateHousehold(sl()));
+  sl.registerLazySingleton<GetHouseholdById>(() => GetHouseholdById(sl()));
+  sl.registerLazySingleton<GetHouseholdMembers>(
+    () => GetHouseholdMembers(sl()),
+  );
+  sl.registerLazySingleton<AddHouseholdMember>(() => AddHouseholdMember(sl()));
+  sl.registerLazySingleton<RemoveHouseholdMember>(
+    () => RemoveHouseholdMember(sl()),
+  );
+  sl.registerLazySingleton<SendRoommateInvite>(() => SendRoommateInvite(sl()));
+  sl.registerLazySingleton<GetInviteById>(() => GetInviteById(sl()));
+  sl.registerLazySingleton<GetHouseholdInvites>(
+    () => GetHouseholdInvites(sl()),
+  );
+  sl.registerLazySingleton<AcceptRoommateInvite>(
+    () => AcceptRoommateInvite(sl()),
+  );
+  sl.registerLazySingleton<RejectRoommateInvite>(
+    () => RejectRoommateInvite(sl()),
+  );
+  sl.registerLazySingleton<ValidateHouseholdMembership>(
+    () => ValidateHouseholdMembership(sl()),
+  );
 
   /// Reports and Insights
   sl.registerLazySingleton<ReportRepository>(

--- a/src/lib/features/sharing_budget/domain/usecases/accept_roommate_invite.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/accept_roommate_invite.dart
@@ -1,0 +1,84 @@
+import '../entities/enums.dart';
+import '../entities/household_member_entity.dart';
+import '../entities/invite_entity.dart';
+import '../repositories/sharing_repository.dart';
+
+/// Result returned after accepting a roommate invitation.
+class AcceptRoommateInviteResult {
+  final InviteEntity invite;
+  final HouseholdMemberEntity member;
+
+  const AcceptRoommateInviteResult({
+    required this.invite,
+    required this.member,
+  });
+}
+
+/// Use case for accepting a roommate invitation.
+///
+/// Validates the invitation, prevents duplicate household membership,
+/// updates the invite status, and creates the household member.
+class AcceptRoommateInvite {
+  final SharingRepository repository;
+
+  const AcceptRoommateInvite(this.repository);
+
+  Future<AcceptRoommateInviteResult> call({
+    required int inviteId,
+    required int userId,
+    MemberRole role = MemberRole.viewer,
+  }) async {
+    if (inviteId <= 0) {
+      throw Exception('Invite ID must be a positive number');
+    }
+
+    if (userId <= 0) {
+      throw Exception('User ID must be a positive number');
+    }
+
+    final invite = await repository.getInviteById(inviteId);
+
+    if (invite == null) {
+      throw Exception('Invite was not found');
+    }
+
+    if (invite.status != InviteStatus.pending) {
+      throw Exception('Only pending invites can be accepted');
+    }
+
+    if (invite.expiresAt.isBefore(DateTime.now())) {
+      throw Exception('Invite has expired');
+    }
+
+    final existingMembers = await repository.getMembersByHousehold(
+      invite.householdId,
+    );
+
+    final alreadyMember = existingMembers
+        .whereType<HouseholdMemberEntity>()
+        .any((member) => member.userId == userId);
+
+    if (alreadyMember) {
+      throw Exception('User is already a member of this household');
+    }
+
+    final updatedInvite = await repository.updateInviteStatus(
+      inviteId,
+      InviteStatus.accepted,
+    );
+
+    final createdMember = await repository.addMember(
+      HouseholdMemberEntity(
+        id: -1,
+        householdId: invite.householdId,
+        userId: userId,
+        role: role,
+      ),
+    );
+
+    return AcceptRoommateInviteResult(
+      invite: updatedInvite,
+      member: createdMember,
+    );
+  }
+}

--- a/src/lib/features/sharing_budget/domain/usecases/add_household_member.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/add_household_member.dart
@@ -1,0 +1,36 @@
+import '../entities/household_member_entity.dart';
+import '../repositories/sharing_repository.dart';
+
+/// Use case for adding a user as a household member.
+///
+/// Includes duplicate prevention so the same user cannot be added
+/// to the same household more than once.
+class AddHouseholdMember {
+  final SharingRepository repository;
+
+  const AddHouseholdMember(this.repository);
+
+  Future<HouseholdMemberEntity> call(HouseholdMemberEntity member) async {
+    if (member.householdId <= 0) {
+      throw Exception('Household ID must be a positive number');
+    }
+
+    if (member.userId <= 0) {
+      throw Exception('User ID must be a positive number');
+    }
+
+    final existingMembers = await repository.getMembersByHousehold(
+      member.householdId,
+    );
+
+    final alreadyMember = existingMembers
+        .whereType<HouseholdMemberEntity>()
+        .any((existingMember) => existingMember.userId == member.userId);
+
+    if (alreadyMember) {
+      throw Exception('User is already a member of this household');
+    }
+
+    return repository.addMember(member);
+  }
+}

--- a/src/lib/features/sharing_budget/domain/usecases/create_household.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/create_household.dart
@@ -1,0 +1,24 @@
+import '../entities/household_entity.dart';
+import '../repositories/sharing_repository.dart';
+
+/// Use case for creating a household.
+///
+/// Keeps household creation logic in the domain/application layer
+/// instead of allowing the presentation layer to call the repository directly.
+class CreateHousehold {
+  final SharingRepository repository;
+
+  const CreateHousehold(this.repository);
+
+  Future<HouseholdEntity> call(HouseholdEntity household) async {
+    if (household.name.trim().isEmpty) {
+      throw Exception('Household name cannot be empty');
+    }
+
+    if (household.ownerId <= 0) {
+      throw Exception('Owner ID must be a positive number');
+    }
+
+    return repository.createHousehold(household);
+  }
+}

--- a/src/lib/features/sharing_budget/domain/usecases/get_household_by_id.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/get_household_by_id.dart
@@ -1,0 +1,17 @@
+import '../entities/household_entity.dart';
+import '../repositories/sharing_repository.dart';
+
+/// Use case for retrieving a household by ID.
+class GetHouseholdById {
+  final SharingRepository repository;
+
+  const GetHouseholdById(this.repository);
+
+  Future<HouseholdEntity?> call(int householdId) async {
+    if (householdId <= 0) {
+      throw Exception('Household ID must be a positive number');
+    }
+
+    return repository.getHouseholdById(householdId);
+  }
+}

--- a/src/lib/features/sharing_budget/domain/usecases/get_household_invites.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/get_household_invites.dart
@@ -1,0 +1,17 @@
+import '../entities/invite_entity.dart';
+import '../repositories/sharing_repository.dart';
+
+/// Use case for retrieving all invitations for a household.
+class GetHouseholdInvites {
+  final SharingRepository repository;
+
+  const GetHouseholdInvites(this.repository);
+
+  Future<List<InviteEntity>> call(int householdId) async {
+    if (householdId <= 0) {
+      throw Exception('Household ID must be a positive number');
+    }
+
+    return repository.getInvitesByHousehold(householdId);
+  }
+}

--- a/src/lib/features/sharing_budget/domain/usecases/get_household_members.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/get_household_members.dart
@@ -1,0 +1,17 @@
+import '../entities/household_member_entity.dart';
+import '../repositories/sharing_repository.dart';
+
+/// Use case for retrieving all members that belong to a household.
+class GetHouseholdMembers {
+  final SharingRepository repository;
+
+  const GetHouseholdMembers(this.repository);
+
+  Future<List<HouseholdMemberEntity>> call(int householdId) async {
+    if (householdId <= 0) {
+      throw Exception('Household ID must be a positive number');
+    }
+
+    return repository.getMembersByHousehold(householdId);
+  }
+}

--- a/src/lib/features/sharing_budget/domain/usecases/get_invite_by_id.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/get_invite_by_id.dart
@@ -1,0 +1,17 @@
+import '../entities/invite_entity.dart';
+import '../repositories/sharing_repository.dart';
+
+/// Use case for retrieving an invitation by ID.
+class GetInviteById {
+  final SharingRepository repository;
+
+  const GetInviteById(this.repository);
+
+  Future<InviteEntity?> call(int inviteId) async {
+    if (inviteId <= 0) {
+      throw Exception('Invite ID must be a positive number');
+    }
+
+    return repository.getInviteById(inviteId);
+  }
+}

--- a/src/lib/features/sharing_budget/domain/usecases/reject_roommate_invite.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/reject_roommate_invite.dart
@@ -1,0 +1,28 @@
+import '../entities/enums.dart';
+import '../entities/invite_entity.dart';
+import '../repositories/sharing_repository.dart';
+
+/// Use case for rejecting a roommate invitation.
+class RejectRoommateInvite {
+  final SharingRepository repository;
+
+  const RejectRoommateInvite(this.repository);
+
+  Future<InviteEntity> call(int inviteId) async {
+    if (inviteId <= 0) {
+      throw Exception('Invite ID must be a positive number');
+    }
+
+    final invite = await repository.getInviteById(inviteId);
+
+    if (invite == null) {
+      throw Exception('Invite was not found');
+    }
+
+    if (invite.status != InviteStatus.pending) {
+      throw Exception('Only pending invites can be rejected');
+    }
+
+    return repository.updateInviteStatus(inviteId, InviteStatus.rejected);
+  }
+}

--- a/src/lib/features/sharing_budget/domain/usecases/remove_household_member.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/remove_household_member.dart
@@ -1,0 +1,16 @@
+import '../repositories/sharing_repository.dart';
+
+/// Use case for removing a household member.
+class RemoveHouseholdMember {
+  final SharingRepository repository;
+
+  const RemoveHouseholdMember(this.repository);
+
+  Future<void> call(int memberId) async {
+    if (memberId <= 0) {
+      throw Exception('Member ID must be a positive number');
+    }
+
+    await repository.removeMember(memberId);
+  }
+}

--- a/src/lib/features/sharing_budget/domain/usecases/send_roommate_invite.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/send_roommate_invite.dart
@@ -1,0 +1,57 @@
+import '../entities/enums.dart';
+import '../entities/invite_entity.dart';
+import '../repositories/sharing_repository.dart';
+
+/// Use case for sending a roommate invitation.
+///
+/// Includes duplicate prevention for active pending invitations
+/// sent to the same email within the same household.
+class SendRoommateInvite {
+  final SharingRepository repository;
+
+  const SendRoommateInvite(this.repository);
+
+  Future<InviteEntity> call(InviteEntity invite) async {
+    if (invite.householdId <= 0) {
+      throw Exception('Household ID must be a positive number');
+    }
+
+    if (invite.invitedByUserId <= 0) {
+      throw Exception('Inviting user ID must be a positive number');
+    }
+
+    if (invite.invitedEmail.trim().isEmpty) {
+      throw Exception('Invited email cannot be empty');
+    }
+
+    if (!invite.invitedEmail.contains('@')) {
+      throw Exception('Invited email must be valid');
+    }
+
+    if (!invite.expiresAt.isAfter(invite.createdAt)) {
+      throw Exception('Invite expiration date must be after creation date');
+    }
+
+    final existingInvites = await repository.getInvitesByHousehold(
+      invite.householdId,
+    );
+
+    final normalizedEmail = invite.invitedEmail.trim().toLowerCase();
+    final now = DateTime.now();
+
+    final duplicatePendingInvite = existingInvites
+        .whereType<InviteEntity>()
+        .any((existingInvite) {
+          return existingInvite.invitedEmail.trim().toLowerCase() ==
+                  normalizedEmail &&
+              existingInvite.status == InviteStatus.pending &&
+              existingInvite.expiresAt.isAfter(now);
+        });
+
+    if (duplicatePendingInvite) {
+      throw Exception('A pending invite already exists for this email');
+    }
+
+    return repository.sendInvite(invite);
+  }
+}

--- a/src/lib/features/sharing_budget/domain/usecases/validate_household_membership.dart
+++ b/src/lib/features/sharing_budget/domain/usecases/validate_household_membership.dart
@@ -1,0 +1,39 @@
+import '../entities/enums.dart';
+import '../repositories/sharing_repository.dart';
+
+/// Use case for validating if a user belongs to a household.
+///
+/// Optionally validates the member role against a list of allowed roles.
+class ValidateHouseholdMembership {
+  final SharingRepository repository;
+
+  const ValidateHouseholdMembership(this.repository);
+
+  Future<bool> call({
+    required int householdId,
+    required int userId,
+    List<MemberRole> allowedRoles = const [],
+  }) async {
+    if (householdId <= 0) {
+      throw Exception('Household ID must be a positive number');
+    }
+
+    if (userId <= 0) {
+      throw Exception('User ID must be a positive number');
+    }
+
+    final members = await repository.getMembersByHousehold(householdId);
+
+    for (final member in members) {
+      if (member.userId == userId) {
+        if (allowedRoles.isEmpty) {
+          return true;
+        }
+
+        return allowedRoles.contains(member.role);
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/lib/features/sharing_budget/sharing_budget_data.dart
+++ b/src/lib/features/sharing_budget/sharing_budget_data.dart
@@ -5,16 +5,29 @@ export 'data/models/household_summary_model.dart';
 export 'data/models/invite_token_model.dart';
 export 'data/models/expense_model.dart';
 export 'data/models/budget_model.dart';
+export 'data/models/invite_model.dart';
+export 'data/models/spend_event_model.dart';
+export 'data/models/budget_allocation_model.dart';
 
 // Data Sources
 export 'data/datasources/household_remote_data_source.dart';
 export 'data/datasources/budget_remote_data_source.dart';
 export 'data/datasources/expense_remote_data_source.dart';
-
-export 'data/models/invite_model.dart';
-export 'data/models/spend_event_model.dart';
-export 'data/models/budget_allocation_model.dart';
 export 'data/datasources/Invitation_remote_data_source.dart';
+
+// Repositories
 export 'data/repositories/budget_repository_impl.dart';
 export 'data/repositories/sharing_repository_impl.dart';
 
+// Sharing Use Cases
+export 'domain/usecases/create_household.dart';
+export 'domain/usecases/get_household_by_id.dart';
+export 'domain/usecases/get_household_members.dart';
+export 'domain/usecases/add_household_member.dart';
+export 'domain/usecases/remove_household_member.dart';
+export 'domain/usecases/send_roommate_invite.dart';
+export 'domain/usecases/get_invite_by_id.dart';
+export 'domain/usecases/get_household_invites.dart';
+export 'domain/usecases/accept_roommate_invite.dart';
+export 'domain/usecases/reject_roommate_invite.dart';
+export 'domain/usecases/validate_household_membership.dart';


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
Closes #672

---

## 📝 Description

### What changed?
- Added Sharing and Budget domain use cases for household management operations.
- Added roommate invitation use cases for sending, accepting, rejecting, and retrieving invitations.
- Added validation and duplicate-prevention logic inside the use case layer.
- Registered the new sharing use cases in dependency injection.
- Updated the Sharing and Budget barrel export file to expose the new use cases.

### Why was this change necessary?
This change was necessary to keep sharing-related business logic inside the application/domain layer instead of having the presentation layer depend directly on repository implementations or data source logic. These use cases provide a clean bridge between future Sharing Cubits/UI flows and the existing SharingRepository interface while maintaining Clean Architecture separation.

---

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] Branch is up to date with base branch

---

## 🧪 Testing (if applicable)

### Test Steps:
1. Created the new sharing use case files under `src/lib/features/sharing_budget/domain/usecases/`.
2. Updated dependency injection and sharing budget exports.
3. Ran targeted analyzer check for the new use case layer.

### Test Results:
`dart analyze src/lib/features/sharing_budget/domain/usecases`

Result:

`No issues found!`

Full project analyze still reports existing unrelated analyzer issues in legacy test files and broader project files outside this issue scope.

---

## 📸 Screenshots/Videos (if applicable)
N/A

---

## 👀 Reviewers
@andreasegarra
@Kay9876
@LuisJCruz