### PR TITLE
Profile screens implementation

### DIFF
--- a/src/lib/config/router.dart
+++ b/src/lib/config/router.dart
@@ -2,11 +2,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
 import 'package:src/core/presentation/routes.dart';
 import 'package:src/features/auth/presentation/routes.dart';
+import 'package:src/features/profile_screens/presentation/routes.dart';
 
 class AppRouter {
   static final GoRouter router = GoRouter(
     initialLocation: "/home",
-    routes: <RouteBase>[mainRoutes, authRoutes],
+    routes: <RouteBase>[mainRoutes, authRoutes, profileRoutes],
   );
 
   static void goTo(BuildContext context, String name) {

--- a/src/lib/core/presentation/routes.dart
+++ b/src/lib/core/presentation/routes.dart
@@ -12,6 +12,8 @@ import 'package:src/features/reports/presentation/routes.dart';
 // TODO: route InviteRoommatePage properly
 import 'package:src/features/alerts_feed/presentation/routes.dart';
 import 'package:src/features/invite_roomate_page/presentation/routes.dart';
+//TDO: route profile screens properly
+import 'package:src/features/profile_screens/presentation/routes.dart';
 
 const List<MainNavTab> _mainTabs = [
   MainNavTab(label: 'Home', icon: Icons.home_filled, rootPath: '/home'),

--- a/src/lib/features/auth/presentation/pages/sign_in_page.dart
+++ b/src/lib/features/auth/presentation/pages/sign_in_page.dart
@@ -33,7 +33,7 @@ class _SignInPageState extends State<SignInPage> {
     }
 
     setState(() => _invalidInfo = false);
-    context.go('/home');
+    context.go('/profile');
   }
 
   @override

--- a/src/lib/features/auth/presentation/pages/sign_up_page.dart
+++ b/src/lib/features/auth/presentation/pages/sign_up_page.dart
@@ -38,7 +38,7 @@ class _SignUpPageState extends State<SignUpPage> {
     }
 
     setState(() => _invalidInfo = false);
-    context.go('/home');
+    context.go('/profile');
   }
 
   @override

--- a/src/lib/features/profile_screens/presentation/cubit/profile_cubit.dart
+++ b/src/lib/features/profile_screens/presentation/cubit/profile_cubit.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:src/features/auth/domain/usecases/get_current_user.dart';
+import 'package:src/features/auth/domain/usecases/sign_out.dart';
+import 'profile_state.dart';
+
+class ProfileCubit extends Cubit<ProfileState> {
+  final GetCurrentUser getCurrentUserUseCase;
+  final SignOut signOutUseCase;
+
+  ProfileCubit({
+    required this.getCurrentUserUseCase,
+    required this.signOutUseCase,
+  }) : super(const ProfileInitial());
+
+  void loadProfile() {
+    final user = getCurrentUserUseCase();
+    if (user != null) {
+      emit(ProfileLoaded(user));
+    } else {
+      emit(const ProfileFailure('No user signed in'));
+    }
+  }
+
+  Future<void> signOut() async {
+    emit(const ProfileLoading());
+    try {
+      await signOutUseCase();
+    } catch (e) {
+      emit(ProfileFailure(e.toString()));
+    }
+  }
+}

--- a/src/lib/features/profile_screens/presentation/cubit/profile_state.dart
+++ b/src/lib/features/profile_screens/presentation/cubit/profile_state.dart
@@ -1,0 +1,23 @@
+import 'package:src/features/auth/domain/entities/auth_user.dart';
+
+abstract class ProfileState {
+  const ProfileState();
+}
+
+class ProfileInitial extends ProfileState {
+  const ProfileInitial();
+}
+
+class ProfileLoading extends ProfileState {
+  const ProfileLoading();
+}
+
+class ProfileLoaded extends ProfileState {
+  final AuthUser user;
+  const ProfileLoaded(this.user);
+}
+
+class ProfileFailure extends ProfileState {
+  final String message;
+  const ProfileFailure(this.message);
+}

--- a/src/lib/features/profile_screens/presentation/pages/account_info_page.dart
+++ b/src/lib/features/profile_screens/presentation/pages/account_info_page.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:src/config/theme.dart';
+import 'package:src/features/profile_screens/presentation/cubit/profile_cubit.dart';
+import 'package:src/features/profile_screens/presentation/cubit/profile_state.dart';
+import 'package:src/features/profile_screens/presentation/widgets/profile_avatar.dart';
+
+const _kCardBg = Color(0xFFEDE8DC);
+const _kRed = Color(0xFFC1440E);
+
+class AccountInfoPage extends StatefulWidget {
+  const AccountInfoPage({super.key});
+
+  @override
+  State<AccountInfoPage> createState() => _AccountInfoPageState();
+}
+
+class _AccountInfoPageState extends State<AccountInfoPage> {
+  bool _editing = false;
+  late final TextEditingController _nameCtrl;
+
+  void _showPhotoOptions() {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 8),
+            Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Colors.grey[300],
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(height: 16),
+            ListTile(
+              leading: const Icon(Icons.photo_library_outlined),
+              title: const Text('Choose from Library'),
+              onTap: () {
+                Navigator.pop(context);
+                // TODO: implement image picker
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.camera_alt_outlined),
+              title: const Text('Take Photo'),
+              onTap: () {
+                Navigator.pop(context);
+                // TODO: implement camera
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.delete_outline, color: Colors.red),
+              title: const Text('Remove Photo',
+                  style: TextStyle(color: Colors.red)),
+              onTap: () => Navigator.pop(context),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+  late final TextEditingController _usernameCtrl;
+  late final TextEditingController _emailCtrl;
+
+  @override
+  void initState() {
+    super.initState();
+    final state = context.read<ProfileCubit>().state;
+    final user = state is ProfileLoaded ? state.user : null;
+    _nameCtrl = TextEditingController(text: user?.name ?? '');
+    _usernameCtrl = TextEditingController();
+    _emailCtrl = TextEditingController(text: user?.email ?? '');
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _usernameCtrl.dispose();
+    _emailCtrl.dispose();
+    super.dispose();
+  }
+
+  Widget _buildField(String label, TextEditingController ctrl) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      decoration: BoxDecoration(
+        color: _kCardBg,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: TextField(
+        controller: ctrl,
+        enabled: _editing,
+        decoration: InputDecoration(
+          labelText: label,
+          labelStyle: TextStyle(color: AppTheme.mutedText, fontSize: 14),
+          border: InputBorder.none,
+        ),
+        style: const TextStyle(
+          fontSize: 15,
+          color: AppTheme.primaryText,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      body: SafeArea(
+        child: BlocBuilder<ProfileCubit, ProfileState>(
+          builder: (context, state) {
+            final avatarUrl =
+                state is ProfileLoaded ? state.user.profilePictureUrl : null;
+
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Column(
+                children: [
+                  const SizedBox(height: 20),
+                  Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: GestureDetector(
+                          onTap: () => Navigator.pop(context),
+                          child: const Icon(Icons.arrow_back_ios,
+                              color: AppTheme.primaryText, size: 20),
+                        ),
+                      ),
+                      const Text(
+                        'Account information',
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w800,
+                          color: AppTheme.primaryText,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  ProfileAvatar(
+                    size: 90,
+                    imageUrl: avatarUrl,
+                    editable: _editing,
+                    onTap: _showPhotoOptions,
+                  ),
+                  const SizedBox(height: 8),
+                  GestureDetector(
+                    onTap: () {
+                      if (_editing) {
+                        // TODO: call update profile use case with _nameCtrl, _usernameCtrl, _emailCtrl values
+                      }
+                      setState(() => _editing = !_editing);
+                    },
+                    child: Text(
+                      _editing ? 'Save' : 'Edit',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: AppTheme.accentColor,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  _buildField('Name', _nameCtrl),
+                  _buildField('Username', _usernameCtrl),
+                  _buildField('Email', _emailCtrl),
+                  GestureDetector(
+                    onTap: () {
+                      // TODO: navigate to change password screen
+                    },
+                    child: Container(
+                      margin: const EdgeInsets.only(bottom: 10),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 16),
+                      decoration: BoxDecoration(
+                        color: _kCardBg,
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            'Change Password',
+                            style: TextStyle(
+                              fontSize: 15,
+                              color: AppTheme.primaryText,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          Text('>',
+                              style: TextStyle(
+                                  color: AppTheme.mutedText, fontSize: 16)),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const Spacer(),
+                  _PrimaryButton(
+                    label: 'Log Out',
+                    onTap: () => Navigator.pop(context),
+                  ),
+                  const SizedBox(height: 4),
+                  _PrimaryButton(
+                    label: 'Delete Account',
+                    color: _kRed,
+                    onTap: () {},
+                  ),
+                  const SizedBox(height: 16),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+  final Color color;
+
+  const _PrimaryButton({
+    required this.label,
+    required this.onTap,
+    this.color = AppTheme.primaryColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onTap,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: color,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(vertical: 10),
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(30)),
+          elevation: 0,
+        ),
+        child: Text(label,
+            style:
+                const TextStyle(fontSize: 14, fontWeight: FontWeight.w700)),
+      ),
+    );
+  }
+}

--- a/src/lib/features/profile_screens/presentation/pages/help_page.dart
+++ b/src/lib/features/profile_screens/presentation/pages/help_page.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:src/config/theme.dart';
+
+const _kCardBg = Color(0xFFEDE8DC);
+const _kRed = Color(0xFFC1440E);
+
+class HelpPage extends StatelessWidget {
+  const HelpPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 20),
+              Stack(
+                alignment: Alignment.center,
+                children: [
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: GestureDetector(
+                      onTap: () => Navigator.pop(context),
+                      child: const Icon(Icons.arrow_back_ios,
+                          color: AppTheme.primaryText, size: 20),
+                    ),
+                  ),
+                  const Text(
+                    'Help',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.w800,
+                      color: AppTheme.primaryText,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: _kCardBg,
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Contact information',
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                        color: AppTheme.primaryText,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Text(
+                      '• homeinven@gmail.com',
+                      style: TextStyle(fontSize: 13, color: AppTheme.mutedText),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '• 787-333-8980',
+                      style: TextStyle(fontSize: 13, color: AppTheme.mutedText),
+                    ),
+                  ],
+                ),
+              ),
+              const Spacer(),
+              _PrimaryButton(
+                label: 'Log Out',
+                onTap: () => Navigator.pop(context),
+              ),
+              const SizedBox(height: 4),
+              _PrimaryButton(
+                label: 'Delete Account',
+                color: _kRed,
+                onTap: () {},
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+  final Color color;
+
+  const _PrimaryButton({
+    required this.label,
+    required this.onTap,
+    this.color = AppTheme.primaryColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onTap,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: color,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(vertical: 10),
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(30)),
+          elevation: 0,
+        ),
+        child: Text(label,
+            style:
+                const TextStyle(fontSize: 14, fontWeight: FontWeight.w700)),
+      ),
+    );
+  }
+}

--- a/src/lib/features/profile_screens/presentation/pages/profile_menu_page.dart
+++ b/src/lib/features/profile_screens/presentation/pages/profile_menu_page.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:src/config/theme.dart';
+import 'package:src/features/profile_screens/presentation/cubit/profile_cubit.dart';
+import 'package:src/features/profile_screens/presentation/cubit/profile_state.dart';
+import 'package:src/features/profile_screens/presentation/routes.dart';
+import 'package:src/features/profile_screens/presentation/widgets/profile_avatar.dart';
+
+const _kCardBg = Color(0xFFEDE8DC);
+const _kRed = Color(0xFFC1440E);
+
+class ProfileMenuPage extends StatelessWidget {
+  const ProfileMenuPage({super.key});
+
+  void _showLogoutDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: const Text('Log Out',
+            style: TextStyle(fontWeight: FontWeight.w700)),
+        content: const Text('Are you sure you want to log out?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: Text('Cancel',
+                style: TextStyle(color: AppTheme.mutedText)),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              context.read<ProfileCubit>().signOut();
+              // TODO: navigate to auth landing after sign out
+              context.go('/auth');
+            },
+            style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.primaryColor),
+            child: const Text('Log Out',
+                style: TextStyle(color: Colors.white)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showDeleteDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: const Text('Delete Account',
+            style: TextStyle(fontWeight: FontWeight.w700, color: _kRed)),
+        content: const Text(
+            'This action is permanent and cannot be undone. Are you sure?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: Text('Cancel',
+                style: TextStyle(color: AppTheme.mutedText)),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              // TODO: call delete account use case
+            },
+            style:
+                ElevatedButton.styleFrom(backgroundColor: _kRed),
+            child: const Text('Delete',
+                style: TextStyle(color: Colors.white)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      body: SafeArea(
+        child: BlocBuilder<ProfileCubit, ProfileState>(
+          builder: (context, state) {
+            final displayName = state is ProfileLoaded
+                ? (state.user.name ?? state.user.email)
+                : 'User';
+            final avatarUrl =
+                state is ProfileLoaded ? state.user.profilePictureUrl : null;
+
+            return SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const SizedBox(height: 20),
+                  Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: GestureDetector(
+                          onTap: () => context.go('/home'),
+                          child: const Icon(Icons.arrow_back_ios,
+                              color: AppTheme.primaryText, size: 20),
+                        ),
+                      ),
+                      Text(
+                        displayName,
+                        style: const TextStyle(
+                          fontSize: 22,
+                          fontWeight: FontWeight.w800,
+                          color: AppTheme.primaryText,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  ProfileAvatar(size: 100, imageUrl: avatarUrl),
+                  const SizedBox(height: 8),
+                  GestureDetector(
+                    onTap: () =>
+                        context.go(ProfileRoutes.accountInfoPath),
+                    child: Text(
+                      'Edit',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: AppTheme.accentColor,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  _MenuRow(
+                    label: 'Account information',
+                    onTap: () =>
+                        context.go(ProfileRoutes.accountInfoPath),
+                  ),
+                  _MenuRow(
+                    label: 'Notifications',
+                    onTap: () {
+                      // TODO: navigate to Notifications screen
+                    },
+                  ),
+                  _MenuRow(
+                    label: 'Settings',
+                    onTap: () =>
+                        context.go(ProfileRoutes.settingsPath),
+                  ),
+                  _MenuRow(
+                    label: 'Help',
+                    onTap: () => context.go(ProfileRoutes.helpPath),
+                  ),
+                  _MenuRow(
+                    label: 'Invite roommates',
+                    onTap: () => context.go(ProfileRoutes.inviteRoommatePath),
+                  ),
+                  const SizedBox(height: 20),
+                  _PrimaryButton(
+                    label: 'Log Out',
+                    onTap: () => _showLogoutDialog(context),
+                  ),
+                  const SizedBox(height: 4),
+                  _PrimaryButton(
+                    label: 'Delete Account',
+                    color: _kRed,
+                    onTap: () => _showDeleteDialog(context),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _MenuRow extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+
+  const _MenuRow({required this.label, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 10),
+        padding:
+            const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
+        decoration: BoxDecoration(
+          color: _kCardBg,
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              label,
+              style: const TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: AppTheme.primaryText,
+              ),
+            ),
+            Text(
+              '>',
+              style: TextStyle(
+                fontSize: 16,
+                color: AppTheme.mutedText,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+  final Color color;
+
+  const _PrimaryButton({
+    required this.label,
+    required this.onTap,
+    this.color = AppTheme.primaryColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onTap,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: color,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(vertical: 10),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(30),
+          ),
+          elevation: 0,
+        ),
+        child: Text(
+          label,
+          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
+        ),
+      ),
+    );
+  }
+}

--- a/src/lib/features/profile_screens/presentation/pages/settings_page.dart
+++ b/src/lib/features/profile_screens/presentation/pages/settings_page.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:src/config/theme.dart';
+
+const _kCardBg = Color(0xFFEDE8DC);
+const _kRed = Color(0xFFC1440E);
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  bool _privateAccount = true;
+  bool _shareContacts = true;
+
+  Widget _buildToggleRow(
+      String label, bool value, ValueChanged<bool> onChanged) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 4),
+      decoration: BoxDecoration(
+        color: _kCardBg,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: AppTheme.primaryText,
+            ),
+          ),
+          Switch(
+            value: value,
+            onChanged: onChanged,
+            activeThumbColor: AppTheme.primaryColor,
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Column(
+            children: [
+              const SizedBox(height: 20),
+              Stack(
+                alignment: Alignment.center,
+                children: [
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: GestureDetector(
+                      onTap: () => Navigator.pop(context),
+                      child: const Icon(Icons.arrow_back_ios,
+                          color: AppTheme.primaryText, size: 20),
+                    ),
+                  ),
+                  const Text(
+                    'Settings',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.w800,
+                      color: AppTheme.primaryText,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              _buildToggleRow(
+                'Private account',
+                _privateAccount,
+                (v) => setState(() => _privateAccount = v),
+              ),
+              _buildToggleRow(
+                'Share contacts',
+                _shareContacts,
+                (v) => setState(() => _shareContacts = v),
+              ),
+              const Spacer(),
+              _PrimaryButton(
+                label: 'Log Out',
+                onTap: () => Navigator.pop(context),
+              ),
+              const SizedBox(height: 4),
+              _PrimaryButton(
+                label: 'Delete Account',
+                color: _kRed,
+                onTap: () {},
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+  final Color color;
+
+  const _PrimaryButton({
+    required this.label,
+    required this.onTap,
+    this.color = AppTheme.primaryColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onTap,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: color,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(vertical: 10),
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(30)),
+          elevation: 0,
+        ),
+        child: Text(label,
+            style:
+                const TextStyle(fontSize: 14, fontWeight: FontWeight.w700)),
+      ),
+    );
+  }
+}

--- a/src/lib/features/profile_screens/presentation/routes.dart
+++ b/src/lib/features/profile_screens/presentation/routes.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:src/config/injection_dependencies.dart';
+import 'package:src/features/auth/domain/usecases/get_current_user.dart';
+import 'package:src/features/auth/domain/usecases/sign_out.dart';
+import 'package:src/features/invite_roomate_page/presentation/routes.dart';
+import 'cubit/profile_cubit.dart';
+import 'pages/account_info_page.dart';
+import 'pages/help_page.dart';
+import 'pages/profile_menu_page.dart';
+import 'pages/settings_page.dart';
+
+abstract final class ProfileRoutes {
+  static const String menuName = 'profile_menu';
+  static const String accountInfoName = 'profile_account_info';
+  static const String settingsName = 'profile_settings';
+  static const String helpName = 'profile_help';
+
+  static const String menuPath = '/profile';
+  static const String accountInfoSegment = 'account-info';
+  static const String settingsSegment = 'settings';
+  static const String helpSegment = 'help';
+
+  static const String accountInfoPath = '$menuPath/$accountInfoSegment';
+  static const String settingsPath = '$menuPath/$settingsSegment';
+  static const String helpPath = '$menuPath/$helpSegment';
+  static const String inviteRoommatePath = '$menuPath/invite_roommate';
+}
+
+ProfileCubit _buildCubit() => ProfileCubit(
+      getCurrentUserUseCase: sl<GetCurrentUser>(),
+      signOutUseCase: sl<SignOut>(),
+    )..loadProfile();
+
+final GoRoute profileRoutes = GoRoute(
+  path: ProfileRoutes.menuPath,
+  name: ProfileRoutes.menuName,
+  builder: (context, state) => BlocProvider(
+    create: (_) => _buildCubit(),
+    child: const ProfileMenuPage(),
+  ),
+  routes: [
+    GoRoute(
+      path: ProfileRoutes.accountInfoSegment,
+      name: ProfileRoutes.accountInfoName,
+      builder: (context, state) => BlocProvider(
+        create: (_) => _buildCubit(),
+        child: const AccountInfoPage(),
+      ),
+    ),
+    GoRoute(
+      path: ProfileRoutes.settingsSegment,
+      name: ProfileRoutes.settingsName,
+      builder: (context, state) => const SettingsPage(),
+    ),
+    GoRoute(
+      path: ProfileRoutes.helpSegment,
+      name: ProfileRoutes.helpName,
+      builder: (context, state) => const HelpPage(),
+    ),
+    inviteRoommateRoutes,
+  ],
+);

--- a/src/lib/features/profile_screens/presentation/widgets/profile_avatar.dart
+++ b/src/lib/features/profile_screens/presentation/widgets/profile_avatar.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:src/config/theme.dart';
+
+class ProfileAvatar extends StatelessWidget {
+  final double size;
+  final String? imageUrl;
+  final bool editable;
+  final VoidCallback? onTap;
+
+  const ProfileAvatar({
+    super.key,
+    this.size = 90,
+    this.imageUrl,
+    this.editable = false,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: editable ? onTap : null,
+      child: Stack(
+        children: [
+          Container(
+            width: size,
+            height: size,
+            decoration: BoxDecoration(
+              color: const Color(0xFFCCCCCC),
+              borderRadius: BorderRadius.circular(size / 2),
+              image: imageUrl != null
+                  ? DecorationImage(
+                      image: NetworkImage(imageUrl!),
+                      fit: BoxFit.cover,
+                    )
+                  : null,
+            ),
+            child: imageUrl == null
+                ? Icon(Icons.person, size: size * 0.55, color: Colors.white70)
+                : null,
+          ),
+          if (editable)
+            Positioned(
+              bottom: 0,
+              right: 0,
+              child: Container(
+                width: size * 0.34,
+                height: size * 0.34,
+                decoration: BoxDecoration(
+                  color: AppTheme.primaryColor,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Colors.white, width: 2),
+                ),
+                child: Icon(
+                  Icons.camera_alt,
+                  color: Colors.white,
+                  size: size * 0.19,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue

Closes #576 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Implemented profile screen with it related screens like settings, help, profile information, delete account and logging out. 
- Routed the invite roommate to the invite roommate button
- Added profile route to the route/core file so it willl be easier to route it when signed in or logged in
-Added route that when signed inor log in, it goes straight to profile

### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
Because it needed a profile with all the user's information.

---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [ x] Code follows project style guidelines
- [x ] Self-review completed
- [ x] Documentation updated
- [ x] Branch is up to date with base branch

---

## 🧪 Testing (if applicable)
<!-- Describe how you tested these changes -->
### Test Steps:
1. Run the simulator of your choice
2. ~/development/flutter/bin/flutter run -d 6CC52A19-E006-417F-823D-404B61C839FC
3. 

### Test Results:
<!-- What was the outcome? -->

You can access the prpfile when logging in (locally)
---

## 📸 Screenshots/Videos (if applicable)

### In the nav bar I put a profile icon with the purpose of testing but eliminate it since it is not part of the design accorded. 

<!-- Add screenshots or videos demonstrating the changes -->
<img width="372" height="763" alt="Screenshot 2026-05-28 at 4 34 28 PM" src="https://github.com/user-attachments/assets/df159bfe-e604-44cc-84e4-96fba589c5af" />
<img width="372" height="763" alt="Screenshot 2026-05-28 at 4 34 33 PM" src="https://github.com/user-attachments/assets/1466f582-5446-443c-af34-1e399e988723" />
<img width="372" height="763" alt="Screenshot 2026-05-28 at 4 34 41 PM" src="https://github.com/user-attachments/assets/59fa890e-56cf-4fe0-ab29-c748520c52de" />
<img width="372" height="763" alt="Screenshot 2026-05-28 at 4 34 48 PM" src="https://github.com/user-attachments/assets/72f8d668-7835-4668-a2fc-165cc8345414" />
<img width="372" height="763" alt="Screenshot 2026-05-28 at 4 34 59 PM" src="https://github.com/user-attachments/assets/3698779c-db19-40c3-96bd-730d0f961a16" />
<img width="372" height="763" alt="Screenshot 2026-05-28 at 4 35 04 PM" src="https://github.com/user-attachments/assets/62fef999-56a2-47bf-8d93-1b08fb810f05" />


---

## 👀 Reviewers
<!-- Tag team members for review -->
@andreasegarra 
@LuisJCruz 
@Kay9876 
