### PR TITLE
Adding Unit Tests for Report Filter Validation Logic

### DIFF
--- a/src/test/features/reports/domain/report_filter_validator_test.dart
+++ b/src/test/features/reports/domain/report_filter_validator_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:src/features/reports/domain/entities/report_filter_validator.dart';
+import 'package:src/features/reports/domain/entities/report_filters.dart';
+
+void main() {
+  group('ReportFilterValidator', () {
+    late ReportFilterValidator validator;
+
+    setUp(() {
+      validator = ReportFilterValidator();
+    });
+
+    test('returns an error when end date is before start date', () async {
+      final result = await validator.validate(
+        ReportFilters(
+          startDate: DateTime(2026, 5, 10),
+          endDate: DateTime(2026, 5, 1),
+          page: 0,
+          searchQuery: '',
+        ),
+        totalAvailableItems: 5,
+      );
+
+      expect(result.isValid, isFalse);
+      expect(result.hasErrors, isTrue);
+      expect(result.hasWarnings, isFalse);
+      expect(result.conflicts, hasLength(1));
+      expect(result.conflicts.single.type, 'end_before_start');
+      expect(result.conflicts.single.severity, ConflictSeverity.error);
+      expect(result.conflicts.single.affectedFields, ['endDate']);
+    });
+
+    test('returns an error when date range is longer than 90 days', () async {
+      final result = await validator.validate(
+        ReportFilters(
+          startDate: DateTime(2026, 1, 1),
+          endDate: DateTime(2026, 4, 5),
+          page: 0,
+          searchQuery: '',
+        ),
+        totalAvailableItems: 5,
+      );
+
+      expect(result.isValid, isFalse);
+      expect(result.hasErrors, isTrue);
+      expect(result.conflicts, hasLength(1));
+      expect(result.conflicts.single.type, 'range_too_long');
+      expect(result.conflicts.single.severity, ConflictSeverity.error);
+      expect(result.conflicts.single.affectedFields, ['startDate', 'endDate']);
+    });
+
+    test(
+      'allows warning-only conflicts without invalidating filters',
+      () async {
+        final result = await validator.validate(
+          ReportFilters(
+            startDate: DateTime.now().subtract(const Duration(days: 2)),
+            endDate: DateTime.now().add(const Duration(days: 1)),
+            page: 0,
+            searchQuery: 'a',
+          ),
+          totalAvailableItems: 0,
+        );
+
+        expect(result.isValid, isTrue);
+        expect(result.hasErrors, isFalse);
+        expect(result.hasWarnings, isTrue);
+        expect(
+          result.conflicts.map((conflict) => conflict.type),
+          containsAll(['future_date', 'no_data', 'broad_search']),
+        );
+        expect(
+          result.conflicts.map((conflict) => conflict.severity),
+          everyElement(ConflictSeverity.warning),
+        );
+      },
+    );
+
+    test(
+      'returns no conflicts for a valid filter set with matching data',
+      () async {
+        final result = await validator.validate(
+          ReportFilters(
+            startDate: DateTime.now().subtract(const Duration(days: 10)),
+            endDate: DateTime.now().subtract(const Duration(days: 1)),
+            page: 0,
+            searchQuery: 'milk',
+          ),
+          totalAvailableItems: 3,
+        );
+
+        expect(result.isValid, isTrue);
+        expect(result.hasErrors, isFalse);
+        expect(result.hasWarnings, isFalse);
+        expect(result.conflicts, isEmpty);
+      },
+    );
+  });
+}


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #702 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Added a test file 
- Tested invalid date ranges, warning-only conflicts, and valid filter inputs.
- Verified that all added tests pass.

### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
- To ensure report filter validation correctly prevents invalid report queries.
- To confirm warning-level conflicts do not incorrectly block report generation.
- To improve test coverage for report filtering logic.

---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] Branch is up to date with base branch

---

## 🧪 Testing (if applicable)
<!-- Describe how you tested these changes -->
### Test Steps:
1. ran cd src flutter test test/features/reports/domain/report_filter_validator_test.dart (the file with the code for the tests)


---

## 📸 Screenshots/Videos (if applicable)
<!-- Add screenshots or videos demonstrating the changes -->
screenshots to demonstrate the passed test
<img width="599" height="108" alt="Screenshot 2026-05-28 at 4 54 47 PM" src="https://github.com/user-attachments/assets/6f795f04-bdf2-4761-9c48-35ab1c6e95c7" />


---

## 👀 Reviewers
<!-- Tag team members for review -->
@LuisJCruz @Kay9876 @kevgom018 
