### PR TITLE
Widget test file created and tested

### DIFF
--- a/src/test/features/auth/presentation/widgets/auth_widgets_test.dart
+++ b/src/test/features/auth/presentation/widgets/auth_widgets_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:src/config/theme.dart';
+import 'package:src/features/auth/presentation/widgets/auth_form_field.dart';
+import 'package:src/features/auth/presentation/widgets/auth_primary_button.dart';
+
+void main() {
+  group('AuthPrimaryButton', () {
+    testWidgets('displays its label', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AuthPrimaryButton(label: 'Sign In', onPressed: () {}),
+          ),
+        ),
+      );
+
+      expect(find.text('Sign In'), findsOneWidget);
+      expect(find.byType(ElevatedButton), findsOneWidget);
+    });
+
+    testWidgets('calls onPressed when tapped', (tester) async {
+      var tapCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AuthPrimaryButton(
+              label: 'Create Account',
+              onPressed: () => tapCount++,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      expect(tapCount, 1);
+    });
+  });
+
+  group('AuthFormField', () {
+    testWidgets('uses invalid hint color when marked invalid', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AuthFormField(
+              hintText: 'Email',
+              controller: controller,
+              isInvalid: true,
+            ),
+          ),
+        ),
+      );
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+
+      expect(field.decoration?.hintText, 'Email');
+      expect(field.decoration?.hintStyle?.color, AppTheme.redAccent);
+    });
+
+    testWidgets('passes text input settings to the TextField', (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AuthFormField(
+              hintText: 'Password',
+              controller: controller,
+              obscureText: true,
+              keyboardType: TextInputType.visiblePassword,
+            ),
+          ),
+        ),
+      );
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+
+      expect(field.obscureText, isTrue);
+      expect(field.keyboardType, TextInputType.visiblePassword);
+      expect(field.controller, controller);
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #703 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Added widget tests for AuthPrimaryButton and AuthFormField
- Verified button rendering, tap behavior, invalid hint styling, and text input settings

### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->
This change improves test coverage for reusable authentication UI components. These widgets are used across authentication screens, so testing them helps prevent regressions in sign-in, sign-up, and account recovery flows.

---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] Branch is up to date with base branch

---


---

## 📸 Screenshots/Videos (if applicable)
<!-- Add screenshots or videos demonstrating the changes -->
<img width="599" height="89" alt="Screenshot 2026-05-28 at 8 32 03 PM" src="https://github.com/user-attachments/assets/9c67bb88-7aa5-44f4-8836-5244caaf1088" />


---

## 👀 Reviewers
<!-- Tag team members for review -->
@Kay9876 @LuisJCruz @kevgom018 
