### PR TITLE
Add Load-Style Test for Repeated Report Filter Validation

### DIFF
--- a/src/test/features/reports/domain/report_filter_validator_load_test.dart
+++ b/src/test/features/reports/domain/report_filter_validator_load_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:src/features/reports/domain/entities/report_filter_validator.dart';
+import 'package:src/features/reports/domain/entities/report_filters.dart';
+
+void main() {
+  group('ReportFilterValidator load-style validation', () {
+    test(
+      'keeps valid filters conflict-free across repeated requests',
+      () async {
+        final validator = ReportFilterValidator();
+        final results = <ValidationResult>[];
+
+        for (var index = 0; index < 500; index++) {
+          final startDate = DateTime.now().subtract(
+            Duration(days: 30 + (index % 10)),
+          );
+          final endDate = DateTime.now().subtract(
+            Duration(days: 1 + (index % 5)),
+          );
+
+          results.add(
+            await validator.validate(
+              ReportFilters(
+                startDate: startDate,
+                endDate: endDate,
+                page: index % 2,
+                searchQuery: 'milk',
+              ),
+              totalAvailableItems: 10,
+            ),
+          );
+        }
+
+        expect(results, hasLength(500));
+        expect(results.every((result) => result.isValid), isTrue);
+        expect(results.every((result) => result.hasErrors), isFalse);
+        expect(results.every((result) => result.hasWarnings), isFalse);
+        expect(results.every((result) => result.conflicts.isEmpty), isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
# Pull Request

## 📋 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #704 

---

## 📝 Description
<!-- Provide a clear description of what this PR does -->
### What changed?
- Added a load-style test for ReportFilterValidator
- Verified all repeated validations stay valid, warning-free, error-free, and conflict-free.


### Why was this change necessary?
<!-- Explain the reasoning behind this implementation -->

This change helps confirm that report filter validation remains consistent when users repeatedly adjust report filters, date ranges, or search terms. It adds confidence that repeated validation requests do not create unexpected conflicts or invalid states.
---

## ✅ Checklist
<!-- Mark completed items with [x] -->
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] Branch is up to date with base branch

---

---

## 📸 Screenshots/Videos (if applicable)
<!-- Add screenshots or videos demonstrating the changes -->

<img width="599" height="89" alt="Screenshot 2026-05-28 at 11 52 10 PM" src="https://github.com/user-attachments/assets/95bd4e17-6045-45a5-916e-1ef245f0373f" />

---

## 👀 Reviewers
<!-- Tag team members for review -->
@kevgom018 @LuisJCruz @Kay9876 
